### PR TITLE
Feature create repository

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,30 @@
+name: Run Unit & Integration Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout to branch
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10.15'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r server/requirements.txt
+
+    - name: Run the tests
+      env:
+        mocker_hub_TEST_ENV: 1
+      run: |
+        pytest server/app/tests/

--- a/client/README.md
+++ b/client/README.md
@@ -9,6 +9,7 @@ npm i react-bootstrap
 npm i zustand
 npm i axios
 npm i react-router-dom
+npm i bootstrap-icons
 npm run dev
 ```
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@popperjs/core": "^2.11.8",
         "axios": "^1.7.7",
         "bootstrap": "^5.3.3",
+        "bootstrap-icons": "^1.11.3",
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.5",
         "react-dom": "^18.3.1",
@@ -2003,6 +2004,21 @@
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+      "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ]
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@popperjs/core": "^2.11.8",
     "axios": "^1.7.7",
     "bootstrap": "^5.3.3",
+    "bootstrap-icons": "^1.11.3",
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.5",
     "react-dom": "^18.3.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,8 +5,32 @@ import { RepoCreate } from './pages/RepoCreate';
 import { UserPasswordChangeRequired } from './pages/UserPasswordChangeRequired';
 import { UserRegistration } from './pages/UserRegistration';
 import { UserLogin } from './pages/UserLogin';
-import { BrowserRouter, Route, Routes } from "react-router";
+import { BrowserRouter, Route, RouteProps, Routes } from "react-router";
 import { UserLogout } from './pages/UserLogout';
+import { ProtectedRoute } from './components/ProtectedRoute';
+
+// This function converts:
+//
+// { <Route path="/new" element={<ProtectedRoute requiredRole={['user', 'admin']}><RepoCreate /></ProtectedRoute>} /> }
+// 
+// Into:
+// { authRoute("/new", ['user', 'admin'], RepoCreate)}
+//
+// Always use it, for readability, unless you have a reason not to. In that case, please document your reasons.
+const authRoute = (
+    path: string,
+    requiredRole: string | string[],
+    Component: React.ComponentType
+): React.ReactElement<RouteProps> => (
+    <Route
+        path={path}
+        element={
+            <ProtectedRoute requiredRole={requiredRole}>
+                <Component />
+            </ProtectedRoute>
+        }
+    />
+);
 
 function App() {
     return (
@@ -14,13 +38,21 @@ function App() {
             <BrowserRouter>
                 <Navbar />
                 <Routes>
-                    <Route path="/" element={<Home />} />
-                    <Route path="/register" element={<UserRegistration />} />
-                    <Route path="/login" element={<UserLogin />} />
-                    <Route path="/password-change-required" element={<UserPasswordChangeRequired />} />
-                    <Route path="/logout" element={<UserLogout />} />
-                    <Route path="/new" element={<RepoCreate />} />
-                    <Route path="*" element={<NotFound />} />
+                    {authRoute("/register", [""], UserRegistration)}
+
+                    {/* Anybody. */}
+                    {authRoute("/", [], Home)}
+                    {authRoute("/login", [], UserLogin)}
+                    {authRoute("/logout", [], UserLogout)}
+
+                    {/* Any role. */}
+                    {authRoute("/password-change-required", ['user', 'admin', 'superadmin'], UserPasswordChangeRequired)}
+
+                    {/* Protected routes. */}
+                    {authRoute("/new", ['user', 'admin'], RepoCreate)}
+
+                    {/* "Not found", must be at the end. */}
+                    {authRoute("*", [], NotFound)}
                 </Routes>
             </BrowserRouter>
         </>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navbar } from './components/Navbar';
 import { Home } from './pages/Home';
 import { NotFound } from './pages/NotFound';
+import { RepoCreate } from './pages/RepoCreate';
 import { UserPasswordChangeRequired } from './pages/UserPasswordChangeRequired';
 import { UserRegistration } from './pages/UserRegistration';
 import { BrowserRouter, Route, Routes } from "react-router";
@@ -15,6 +16,7 @@ function App() {
                     <Route path="/" element={<Home />} />
                     <Route path="/register" element={<UserRegistration />} />
                     <Route path="/password-change-required" element={<UserPasswordChangeRequired />} />
+                    <Route path="/new" element={<RepoCreate />} />
                     <Route path="*" element={<NotFound />} />
                 </Routes>
             </BrowserRouter>

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -1,0 +1,28 @@
+import { AxiosResponse } from "axios";
+import { axiosInstance } from "../util/http";
+
+export interface RepoCreateDTO {
+    name: string,
+    desc: string,
+    public: boolean,
+    organization_id: number | null,
+    owner_id: number, // TODO: Once we have authorization, we should extract the ID from the JWT instead.
+}
+
+export interface RepoDTO {
+    id: number,
+    name: string,
+    canonical_name: string,
+    desc: string
+    public: boolean,
+    official: boolean,
+    owner_id: number,
+    organization_id: number,
+}
+
+
+export class RepositoryService {
+    static async CreateRepository(dto: RepoCreateDTO): Promise<AxiosResponse<RepoDTO>> {
+        return await axiosInstance.post(`/repositories`, dto);
+    }
+}

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -6,7 +6,6 @@ export interface RepoCreateDTO {
     desc: string,
     public: boolean,
     organization_id: number | null,
-    owner_id: number, // TODO: Once we have authorization, we should extract the ID from the JWT instead.
 }
 
 export interface RepoDTO {

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -19,13 +19,13 @@ export function Navbar() {
             {
                 role === 'user' &&
                 <>
-                    <NavLink className={"navlink"} to="/new" end>[ + ]</NavLink>
+                    <NavLink className={"navlink"} to="/new" end>New repo</NavLink>
                 </>
             }
             {
                 role === 'admin' &&
                 <>
-                    <NavLink className={"navlink"} to="/new" end>[ + ]</NavLink>
+                    <NavLink className={"navlink"} to="/new" end>New repo</NavLink>
                 </>
             }
             {

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -19,11 +19,13 @@ export function Navbar() {
             {
                 role === 'user' &&
                 <>
+                    <NavLink className={"navlink"} to="/new" end>[ + ]</NavLink>
                 </>
             }
             {
                 role === 'admin' &&
                 <>
+                    <NavLink className={"navlink"} to="/new" end>[ + ]</NavLink>
                 </>
             }
             {

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../util/store';
+
+interface ProtectedRouteProps {
+    children: React.ReactNode;
+    requiredRole?: string | string[];
+}
+
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, requiredRole }) => {
+    const role = useAuthStore((state) => state.role);
+
+    if (requiredRole) {
+        const roles = Array.isArray(requiredRole) ? requiredRole : [requiredRole];
+        const hasRequiredRole = roles.length == 0 || roles.includes(role);
+
+        if (!hasRequiredRole) {
+            if (!role) {
+                console.error("Please sign in");
+                return <Navigate to="/login" />;
+            }
+
+            console.error(`You are unauthorized to access this route. Allowed roles: ${requiredRole}. Your role: ${role}.`);
+            return <Navigate to="/" />;
+        }
+    }
+
+    return children;
+};

--- a/client/src/pages/RepoCreate.css
+++ b/client/src/pages/RepoCreate.css
@@ -1,0 +1,10 @@
+.repo-create {
+    padding: 20px 27%;
+    border-radius: 10px;
+
+    .is-public-radiogroup,
+    .desc-formgroup {
+        margin-top: 30px;
+        margin-bottom: 30px;
+    }
+}

--- a/client/src/pages/RepoCreate.tsx
+++ b/client/src/pages/RepoCreate.tsx
@@ -3,6 +3,7 @@ import { Form, Button, DropdownButton, Dropdown, Col, Row, Alert } from 'react-b
 import './RepoCreate.css';
 import { RepoCreateDTO, RepoDTO, RepositoryService } from '../api/repo.api';
 import { AxiosError } from 'axios';
+import { getJwtId } from '../util/localstorage';
 
 interface Owner {
     name: string;
@@ -28,7 +29,7 @@ export const RepoCreate = () => {
         ];
 
         const all_possible_owners = [
-            { name: "user 1", user_id: 1, organization_id: null },
+            { name: "user 1", user_id: getJwtId(), organization_id: null },
             ...organizations_i_can_make_repos_in
         ]
 
@@ -46,7 +47,7 @@ export const RepoCreate = () => {
 
     const userOrOrgToStr = (owner: Owner) => {
         if (owner.user_id != null) {
-            return `User ${owner.user_id} (You)`;
+            return `(You)`;
         }
         if (owner.organization_id != null) {
             return `Organization ${owner.organization_id}`;
@@ -86,8 +87,6 @@ export const RepoCreate = () => {
             name: data.name,
             public: data.isPublic,
             organization_id: owner!.organization_id,
-
-            owner_id: owners[0].user_id!,
         };
 
         setError('');

--- a/client/src/pages/RepoCreate.tsx
+++ b/client/src/pages/RepoCreate.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { Form, Button, DropdownButton, Dropdown, Col, Row, Alert } from 'react-bootstrap';
+import './RepoCreate.css';
+
+interface Owner {
+    name: string;
+    user_id: number | null;
+    organization_id: number | null;
+}
+
+export const RepoCreate = () => {
+    const [name, setName] = useState('');
+    const [owner, setOwner] = useState<Owner | null>(null);
+    const [description, setDescription] = useState('');
+    const [isPublic, setIsPublic] = useState(true);
+    const [owners, setOwners] = useState<Owner[]>([]);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        // Load possible owners and organizations.
+
+        setOwners([
+            { name: "user 1", user_id: 1, organization_id: null },
+            { name: "org 1", user_id: null, organization_id: 1 },
+            { name: "org 2", user_id: null, organization_id: 2 },
+        ]);
+
+        // Set initial owner as the user who's currently logged in.
+
+        setOwner(owners[0]);
+    }, []);
+
+    const userOrOrgToStr = (owner: Owner) => {
+        if (owner.user_id != null) {
+            return `User ${owner.user_id} (You)`;
+        }
+        if (owner.organization_id != null) {
+            return `Organization ${owner.organization_id}`;
+        }
+        console.error(`Bad owner object: ${owner}`);
+    }
+
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        const data = {
+            name,
+            owner,
+            description,
+            isPublic,
+        };
+
+        if (!data.name.trim()) {
+            setError("You must enter the name of the repository.");
+            return;
+        }
+
+        setError('');
+
+        //console.log('Repository:', repository);
+    };
+
+    return (
+        <Form onSubmit={handleSubmit} className="repo-create">
+            <h1>Create a new repository</h1>
+
+            <Row>
+                <Col xs="auto">
+                    <Form.Group controlId="formOwner">
+                        <Form.Label>Owner</Form.Label>
+                        <DropdownButton
+                            id="dropdown-owner"
+                            title={owner ? `${userOrOrgToStr(owner)}` : 'Select Owner'}
+                            onSelect={(eventKey) => {
+                                const selectedOwner = owners.find((o) => o.name === eventKey);
+                                setOwner(selectedOwner || null);
+                            }}
+                        >
+                            {owners.map((o) => (
+                                <Dropdown.Item key={o.user_id} eventKey={o.name}>
+                                    {o.user_id} / {o.organization_id}
+                                </Dropdown.Item>
+                            ))}
+                        </DropdownButton>
+                    </Form.Group>
+                </Col>
+                <Col>
+                    <Form.Group controlId="formName">
+                        <Form.Label>Name</Form.Label>
+                        <Form.Control
+                            type="text"
+                            placeholder="Enter repository name"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                        />
+                    </Form.Group>
+                </Col>
+            </Row>
+            {/* 
+            <Form.Group controlId="formName">
+                <Form.Label>Owner</Form.Label>
+                <DropdownButton
+                    id="dropdown-owner"
+                    title={owner ? `${userOrOrgToStr(owner)}` : 'Select Owner'}
+                    onSelect={(eventKey) => {
+                        const selectedOwner = owners.find((o) => o.name === eventKey);
+                        setOwner(selectedOwner || null);
+                    }}
+                >
+                    {owners.map((o) => (
+                        <Dropdown.Item key={o.user_id} eventKey={o.name}>
+                            {o.user_id} / {o.organization_id}
+                        </Dropdown.Item>
+                    ))}
+                </DropdownButton>
+
+                <Form.Label>Name</Form.Label>
+                <Form.Control
+                    type="text"
+                    placeholder="Enter repository name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                />
+
+            </Form.Group> */}
+
+            <Form.Group controlId="formDescription" className='desc-formgroup'>
+                <Form.Label>Description (Optional)</Form.Label>
+                <Form.Control
+                    as="textarea"
+                    rows={3}
+                    placeholder=""
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                />
+            </Form.Group>
+
+            <Form.Group controlId="formPublic" className='is-public-radiogroup'>
+                <div>
+                    <Form.Check
+                        type="radio"
+                        label={<><i className="bi bi-journal-bookmark"></i> <b>Public</b> - Anyone can see and pull from this repository</>}
+                        name="visibility"
+                        checked={isPublic}
+                        onChange={() => setIsPublic(true)}
+                    />
+                    <Form.Check
+                        type="radio"
+                        label={<><i className="bi bi-lock"></i> <b>Private</b> - Only you have access to this repository</>}
+                        name="visibility"
+                        checked={!isPublic}
+                        onChange={() => setIsPublic(false)}
+                    />
+                </div>
+            </Form.Group>
+
+            {error && <Alert variant="danger">{error}</Alert>}
+
+            <div className="d-flex justify-content-end">
+                <Button variant="primary" type="submit">
+                    Create Repository
+                </Button>
+            </div>
+        </Form>
+    );
+};

--- a/client/src/pages/UserLogin.tsx
+++ b/client/src/pages/UserLogin.tsx
@@ -41,13 +41,13 @@ export const UserLogin = () => {
         UserService.LoginUser(dto).then((res) => {
             let token: TokenDTO = res.data;
             setJWT(token.token);
-            setRole(getJwtRole());
-
-            if (getJwtMustChangePassword()) {
-                navigate("/password-change-required");
-            } else {
-                navigate("/");
-            }
+            setRole(getJwtRole(), () => {
+                if (getJwtMustChangePassword()) {
+                    navigate("/password-change-required");
+                } else {
+                    navigate("/new");
+                }
+            });
         }).catch((err: AxiosError) => {
             console.error(err);
             setError((err.response?.data as any)["detail"]["message"]);

--- a/client/src/scss/styles.scss
+++ b/client/src/scss/styles.scss
@@ -1,1 +1,2 @@
 @import "~bootstrap/scss/bootstrap";
+@import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css");

--- a/client/src/util/store.ts
+++ b/client/src/util/store.ts
@@ -3,10 +3,13 @@ import { getJwtRole } from "./localstorage";
 
 interface AuthState {
     role: string;
-    setRole: (role: string) => void;
+    setRole: (role: string, callback?: () => void) => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
     role: getJwtRole(),
-    setRole: (val: string) => set({ role: val }),
+    setRole: (role, callback) => {
+        set({ role }, false);
+        if (callback) callback();
+    },
 }));

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,7 @@ services:
           target: /code
     
     volumes:
-      - backend_cfg:/code/cfg/
+      - backend_cfg:/code/volume-server-cfg/
 
   db:
     image: postgres:15.9-alpine3.20

--- a/server/README.md
+++ b/server/README.md
@@ -4,6 +4,8 @@ This is the main API server.
 
 ## Getting started
 
+Requires Python 3.10 (version 3.11 and possibly newer will not work due to issues with `aioredis` and `fastapi-cache`).
+
 1) Install the required packages: `pip install -r server/requirements.txt`
 2) Run the development server: `fastapi dev server/api/main.py`
 3) Check the CLI for the server IP address and the auto-generated OpenAPI docs

--- a/server/app/api/config/auth.py
+++ b/server/app/api/config/auth.py
@@ -23,8 +23,13 @@ from functools import wraps
 from typing import List, Callable
 
 
-JWT_SECRET = os.environ['JWT_SECRET']
-JWT_ALGORITHM = os.environ['JWT_ALGORITHM']
+if os.getenv('mocker_hub_TEST_ENV') is not None:
+    print("[!] Detected environment variable mocker_hub_TEST_ENV -> setting up unsafe JWT envirnoment")
+    JWT_SECRET = 'Test1234'
+    JWT_ALGORITHM = 'HS256'
+else:
+    JWT_SECRET = os['JWT_SECRET']
+    JWT_ALGORITHM = os.environ['JWT_ALGORITHM']
 
 
 class JWTBearer(HTTPBearer):
@@ -59,7 +64,6 @@ def sign_jwt(user: User) -> str:
         "role": user.role.value,
         "must_change_password": user.must_change_password,
     }
-    print(payload)
     return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 

--- a/server/app/api/config/cache.py
+++ b/server/app/api/config/cache.py
@@ -3,8 +3,38 @@ from fastapi_cache import FastAPICache
 from fastapi_cache.backends.redis import RedisBackend
 from redis import asyncio as aioredis
 
-def init_cache():
-    hostname = os.environ['REDIS_HOST']
-    port = os.environ['REDIS_PORT']
-    redis = aioredis.from_url(f"redis://{hostname}:{port}")
-    FastAPICache.init(RedisBackend(redis), prefix="fastapi-cache")
+# When you want to use cache, you just import the decorator:
+#
+# from fastapi_cache.decorator import cache
+#
+# @cache
+# def f(...)
+#
+# But when calling `f`, an exception will be raised in case Redis
+# isn't set up. When we're doing e.g. integration tests, we don't
+# have Redis set up, so we have to mock `cache` into a no-op.
+#
+# This means that you have to import `cache` from _here_, and not
+# from `fastapi_cache.decorator`.
+if os.getenv('mocker_hub_TEST_ENV') is not None:
+    print("[!] Detected environment variable mocker_hub_TEST_ENV -> not using cache")
+
+    def no_op(expire=None):
+        def decorator(func):
+            return func
+        return decorator
+
+    def cache(expire=None):
+        return no_op(expire)
+    
+    def init_cache():
+        ...
+else:
+    from fastapi_cache.decorator import cache as _cache
+    cache = _cache
+
+    def init_cache():
+        hostname = os.environ['REDIS_HOST']
+        port = os.environ['REDIS_PORT']
+        redis = aioredis.from_url(f"redis://{hostname}:{port}")
+        FastAPICache.init(RedisBackend(redis), prefix="fastapi-cache")

--- a/server/app/api/config/database.py
+++ b/server/app/api/config/database.py
@@ -2,14 +2,26 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import Session as SQLModelSession
+from sqlalchemy.pool import StaticPool
 
-postgre_hostname = "db"
-postgre_db = os.environ.get('POSTGRES_DATABASE', None)
-postgre_user = os.environ.get('POSTGRES_USER', None)
-postgre_password = os.environ.get('POSTGRES_PASSWORD', None)
-database_url = f"postgresql://{postgre_user}:{postgre_password}@{postgre_hostname}/{postgre_db}"
+if os.getenv('mocker_hub_TEST_ENV') is not None:
+    print("[!] Detected environment variable mocker_hub_TEST_ENV -> using SQLite")
 
-engine = create_engine(database_url)
+    # To make the database truly in-memory, you need to specify a static 
+    # pool which uses only one connection, shared between all requests.
+    engine = create_engine(
+        "sqlite://", 
+        connect_args={"check_same_thread": False}, 
+        poolclass=StaticPool
+    )
+else:
+    postgre_hostname = "db"
+    postgre_db = os.environ.get('POSTGRES_DATABASE', None)
+    postgre_user = os.environ.get('POSTGRES_USER', None)
+    postgre_password = os.environ.get('POSTGRES_PASSWORD', None)
+    database_url = f"postgresql://{postgre_user}:{postgre_password}@{postgre_hostname}/{postgre_db}"
+
+    engine = create_engine(database_url)
 
 SessionLocal = sessionmaker(
     # https://github.com/fastapi/sqlmodel/issues/75#issuecomment-2109911909

--- a/server/app/api/config/initialize.py
+++ b/server/app/api/config/initialize.py
@@ -26,7 +26,7 @@ def configure_cors(app: FastAPI):
 def init_superadmin():
     session = next(get_database())
     service = UserService(session)
-    config_file = "./cfg/superadmin_password.txt"
+    config_file = "./volume-server-cfg/superadmin_password.txt"
     
     print("Checking for superadmin...")
     existing_superadmin = session.exec(select(User).where(User.role == UserRole.superadmin)).first()

--- a/server/app/api/main.py
+++ b/server/app/api/main.py
@@ -5,10 +5,12 @@ from pydantic import ValidationError
 from app.api.config.initialize import init_create_tables, configure_cors, init_superadmin
 from app.api.config.exception_handler import register_exception_handler
 import app.api.user.user_controller
+import app.api.repo.repo_controller
 from app.api.config.cache import init_cache
 
 the_router = APIRouter()
 the_router.include_router(app.api.user.user_controller.router)
+the_router.include_router(app.api.repo.repo_controller.router)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -6,6 +6,6 @@ from app.api.repo.repo_service import RepositoryService, get_repo_service
 router = APIRouter(prefix="/repositories", tags=["repositories"])
 
 @router.post("/", response_model=RepositoryDTO, status_code=200, summary="Create a new repository")
-def register_user(dto: RepositoryCreateDTO, repo_service: RepositoryService = Depends(get_repo_service)):
+def register_repo(dto: RepositoryCreateDTO, repo_service: RepositoryService = Depends(get_repo_service)):
     repo = repo_service.add(dto)
     return repo

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -2,10 +2,15 @@ from fastapi import APIRouter, Depends
 
 from app.api.repo.repo_dto import RepositoryCreateDTO, RepositoryDTO
 from app.api.repo.repo_service import RepositoryService, get_repo_service
+from app.api.config.auth import get_id_from_jwt, pre_authorize
+from app.api.user.user_model import UserRole
+from app.api.config.auth import JWTBearer, JWTDep
 
 router = APIRouter(prefix="/repositories", tags=["repositories"])
 
 @router.post("/", response_model=RepositoryDTO, status_code=200, summary="Create a new repository")
-def register_repo(dto: RepositoryCreateDTO, repo_service: RepositoryService = Depends(get_repo_service)):
-    repo = repo_service.add(dto)
+@pre_authorize([UserRole.user, UserRole.admin], ignore_password_change_requirement=True)
+def register_repo(jwt: JWTDep, dto: RepositoryCreateDTO, repo_service: RepositoryService = Depends(get_repo_service)):
+    user_id = get_id_from_jwt(jwt)
+    repo = repo_service.add(user_id, dto)
     return repo

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Depends
+
+from app.api.repo.repo_dto import RepositoryCreateDTO, RepositoryDTO
+from app.api.repo.repo_service import RepositoryService, get_repo_service
+
+router = APIRouter(prefix="/repositories", tags=["repositories"])
+
+@router.post("/", response_model=RepositoryDTO, status_code=200, summary="Create a new repository")
+def register_user(dto: RepositoryCreateDTO, repo_service: RepositoryService = Depends(get_repo_service)):
+    repo = repo_service.add(dto)
+    return repo

--- a/server/app/api/repo/repo_dto.py
+++ b/server/app/api/repo/repo_dto.py
@@ -18,5 +18,3 @@ class RepositoryCreateDTO(BaseModel):
     desc: str
     public: bool
     organization_id: int | None = None
-
-    owner_id: int # TODO: Once we have authorization, we should extract the ID from the JWT instead.

--- a/server/app/api/repo/repo_dto.py
+++ b/server/app/api/repo/repo_dto.py
@@ -1,0 +1,22 @@
+import datetime
+from pydantic import BaseModel, EmailStr, Field
+from app.api.user.user_model import UserRole
+
+class RepositoryDTO(BaseModel):
+    id: int
+    name: str
+    canonical_name: str
+    desc: str
+    public: bool
+    official: bool
+    owner_id: int
+    organization_id: int | None = None
+
+
+class RepositoryCreateDTO(BaseModel):
+    name: str
+    desc: str
+    public: bool
+    organization_id: int | None = None
+
+    owner_id: int # TODO: Once we have authorization, we should extract the ID from the JWT instead.

--- a/server/app/api/repo/repo_model.py
+++ b/server/app/api/repo/repo_model.py
@@ -1,0 +1,37 @@
+from sqlmodel import Field, Relationship, SQLModel
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from app.api.user.user_model import User
+
+class Repository(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field()
+    """
+    Name of the repository.
+    """
+    canonical_name: str = Field(index=True)
+    """
+    The canonical name of a repository. Must be unique.
+    It is set once during repository creation and **should not change**.
+
+    For official repositories, it is equal to `{name}`.
+
+    For user repositories, it is equal to `{owner.username}/{name}`.
+    """
+    desc: str = Field(default="")
+    public: bool = Field(default=True)
+    official: bool = Field(default=False)
+    """
+    Official repositories are created and maintained by administrators.
+    """
+
+    owner_id: int = Field(default=None, foreign_key="user.id")
+    owner: "User" = Relationship(back_populates="repositories")
+
+
+    def compute_canonical_name(this) -> str:
+        if this.official:
+            return f'{this.name}'
+        else:
+            return f'{this.owner.username}/{this.name}'

--- a/server/app/api/repo/repo_repo.py
+++ b/server/app/api/repo/repo_repo.py
@@ -1,0 +1,20 @@
+from sqlmodel import Session, select
+from app.api.repo.repo_model import Repository
+from app.api.user.user_model import User
+
+class RepositoryRepo:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def add(self, repo: Repository) -> Repository:
+        self.session.add(repo)
+        self.session.commit()
+        self.session.refresh(repo)
+        return repo    
+    
+    def find_by_id(self, id: int) -> Repository | None:
+        return self.session.get(User, id)
+        
+    def find_by_canonical_name(self, canonical_name: str) -> Repository | None:
+        return self.session.exec(select(Repository).where(Repository.canonical_name == canonical_name)).first()
+    

--- a/server/app/api/repo/repo_service.py
+++ b/server/app/api/repo/repo_service.py
@@ -14,12 +14,12 @@ class RepositoryService:
         self.repo_repo = RepositoryRepo(session)
         self.user_repo = UserRepo(session)
 
-    def add(self, dto: RepositoryCreateDTO) -> Repository:
+    def add(self, user_id: int, dto: RepositoryCreateDTO) -> Repository:
         # Find the User who's creating the repository.
 
-        owner = self.user_repo.find_by_id(dto.owner_id)
+        owner = self.user_repo.find_by_id(user_id)
         if owner is None:
-            raise NotFoundException(User, dto.owner_id)
+            raise NotFoundException(User, user_id)
         repo_is_official = owner.role == UserRole.admin 
 
         # TODO: Find the organization this repository is created for (if any).
@@ -27,6 +27,7 @@ class RepositoryService:
         organization = None # self.organization_repo.find_by_id(dto.organization.id)
         org_name = None
         if organization is not None:
+            print("Warning - organizations are not implemented yet. Ignoring the organization field...")
             org_name = ...
         
         # Compute the canonical name of the repository.

--- a/server/app/api/repo/repo_service.py
+++ b/server/app/api/repo/repo_service.py
@@ -1,0 +1,50 @@
+from fastapi import Depends
+from app.api.config.exception_handler import FieldTakenException, NotFoundException
+from sqlmodel import Session
+from app.api.config.database import get_database
+from app.api.user.user_model import User, UserRole
+from app.api.user.user_repo import UserRepo
+from app.api.repo.repo_repo import RepositoryRepo
+from app.api.repo.repo_model import Repository
+from app.api.repo.repo_dto import RepositoryCreateDTO
+ 
+class RepositoryService:
+    def __init__(self, session: Session):
+        self.session = session
+        self.repo_repo = RepositoryRepo(session)
+        self.user_repo = UserRepo(session)
+
+    def add(self, dto: RepositoryCreateDTO) -> Repository:
+        # Find the User who's creating the repository.
+
+        owner = self.user_repo.find_by_id(dto.owner_id)
+        if owner is None:
+            raise NotFoundException(User, dto.owner_id)
+        repo_is_official = owner.role == UserRole.admin 
+
+        # TODO: Find the organization this repository is created for (if any).
+
+        organization = None # self.organization_repo.find_by_id(dto.organization.id)
+        org_name = None
+        if organization is not None:
+            org_name = ...
+        
+        # Compute the canonical name of the repository.
+
+        canonical_name = Repository.compute_canonical_name(dto.name, owner.username, repo_is_official, org_name)
+        if self.repo_repo.find_by_canonical_name(canonical_name):
+            raise FieldTakenException("Repository name")
+
+        # Create the new repository.
+
+        new_repo = Repository.model_validate(dto, update={
+            "canonical_name": canonical_name,
+            "official": repo_is_official,
+            "owner_id": owner.id,
+        })
+
+        return self.repo_repo.add(new_repo)
+
+
+def get_repo_service(session: Session = Depends(get_database)) -> RepositoryService:
+    return RepositoryService(session)

--- a/server/app/api/user/user_controller.py
+++ b/server/app/api/user/user_controller.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from fastapi import APIRouter, Depends
 
-from app.api.user.user_dto import UserPasswordChangeDTO, UserRegisterDTO, UserLoginDTO, UserTokenDTO
+from app.api.user.user_dto import UserDTO, UserPasswordChangeDTO, UserRegisterDTO, UserLoginDTO, UserTokenDTO
 from app.api.user.user_service import UserService, get_user_service
 from app.api.user.user_model import UserRole
 from fastapi_cache.decorator import cache
@@ -10,9 +10,9 @@ from app.api.config.auth import pre_authorize
 
 router = APIRouter(prefix="/users", tags=["users"])
 
-@router.post("/", status_code=201, summary="Register a new regular user")
+@router.post("/", response_model=UserDTO, summary="Register a new regular user")
 def register_user(dto: UserRegisterDTO, user_service: UserService = Depends(get_user_service)): 
-    user_service.add(dto)
+    return user_service.add(dto)
 
 @router.post("/login", response_model=UserTokenDTO, status_code=200, summary="Log in to your profile")
 def login_user(dto: UserLoginDTO, user_service: UserService = Depends(get_user_service)):
@@ -29,7 +29,6 @@ def change_user_password(jwt: JWTDep, dto: UserPasswordChangeDTO, user_service: 
 @cache(expire=10)
 @pre_authorize(["superadmin"])
 def test(jwt: JWTDep):
-    print(get_id_from_jwt(jwt))
     return [
         { "id": 0, "name": "Aza" },
         { "id": 1, "name": "Bub" },

--- a/server/app/api/user/user_controller.py
+++ b/server/app/api/user/user_controller.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 
 from app.api.user.user_dto import UserDTO, UserPasswordChangeDTO, UserRegisterDTO
 from app.api.user.user_service import UserService, get_user_service
-from fastapi_cache.decorator import cache
+from app.api.config.cache import cache
 
 router = APIRouter(prefix="/users", tags=["users"])
 

--- a/server/app/api/user/user_model.py
+++ b/server/app/api/user/user_model.py
@@ -1,7 +1,9 @@
 import datetime
 import enum
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, Relationship, SQLModel
 from pydantic import EmailStr
+
+from app.api.repo.repo_model import Repository
 
 class UserRole(str, enum.Enum):
     user = "user"
@@ -17,3 +19,5 @@ class User(SQLModel, table=True):
     
     hashed_password: str
     must_change_password: bool = Field(default=False)
+
+    repositories: list["Repository"] = Relationship(back_populates="owner")

--- a/server/app/api/user/user_service.py
+++ b/server/app/api/user/user_service.py
@@ -54,8 +54,6 @@ class UserService:
             raise NotFoundException(User, dto.username)
         if not verify_password(dto.password, user.hashed_password):
             raise UserException("Username or password incorrect")
-        
-        print(user)
 
         return sign_jwt(user)
 

--- a/server/app/tests/README.md
+++ b/server/app/tests/README.md
@@ -1,1 +1,14 @@
-Run the tests with the `pytest` command.
+## Running the tests
+
+1) Position yourself to the root of this repository. We need to do this because of ./volume-server-cfg.
+
+```sh
+user:.../mocker-hub/server/app/tests$ cd ../../../
+user:.../mocker-hub$
+```
+
+2) Run the tests. `-s` is to show stdout from `print()`.
+
+```sh
+mocker_hub_TEST_ENV=1 pytest server/app/tests/ -s
+```

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -1,0 +1,142 @@
+from fastapi.testclient import TestClient
+import pytest
+import unittest.mock as mock
+
+from sqlmodel import Session
+
+from app.api.config.security import hash_password
+from app.api.user.user_dto import UserPasswordChangeDTO
+from app.api.user.user_model import User, UserRole
+from app.api.user.user_repo import UserRepo
+from app.api.user.user_service import UserService
+from app.api.config.exception_handler import FieldTakenException, NotFoundException, UserException
+from app.api.repo.repo_repo import RepositoryRepo
+from app.api.repo.repo_service import RepositoryService
+from app.api.repo.repo_dto import RepositoryCreateDTO
+from app.api.repo.repo_model import Repository
+from app.api.main import app
+
+@pytest.fixture
+def mock_session():
+    return mock.MagicMock(spec=Session)
+
+@pytest.fixture
+def mock_user_repo():
+    return mock.MagicMock(spec=UserRepo)
+
+@pytest.fixture
+def mock_repo_repo():
+    return mock.MagicMock(spec=RepositoryRepo)
+
+@pytest.fixture
+def user_service(mock_session, mock_user_repo):
+    service = UserService(mock_session)
+    service.user_repo = mock_user_repo
+    return service
+
+@pytest.fixture
+def repo_service(mock_session):
+    service = RepositoryService(mock_session)
+    service.repo_repo = mock.MagicMock(spec=RepositoryRepo)
+    service.user_repo = mock.MagicMock(spec=UserRepo)
+    return service
+
+def create_mock_user(id: int, username: str, role: UserRole):
+    return User(id=id, email=f"username@email.com", username=username, role=role, hashed_password=hash_password("1234"))
+
+
+client = TestClient(app)
+
+
+def test_add_repo(repo_service):
+    user1 = create_mock_user(1, "user1", UserRole.user)
+
+    repo_service.user_repo.find_by_id.return_value = user1
+    repo_service.repo_repo.find_by_canonical_name.return_value = None
+
+    dto = RepositoryCreateDTO(
+        name="Some repo",
+        desc="",
+        public=True,
+        organization_id=None,
+        owner_id=user1.id
+    )
+
+    repo_result = repo_service.add(dto)
+
+    assert repo_result.id is not None
+
+def test_add_repo__no_user(repo_service):
+    repo_service.user_repo.find_by_id.return_value = None
+    dto = RepositoryCreateDTO(
+        name="Some repo",
+        desc="",
+        public=True,
+        organization_id=None,
+        owner_id=1
+    )
+
+    with pytest.raises(NotFoundException) as e:
+        repo_service.add(dto)
+    
+    assert e.value.entity_type == User
+    assert e.value.identifier == 1
+
+def test_add_repo__repo_name(repo_service):
+    user1 = create_mock_user(1, "user1", UserRole.user)
+    user2 = create_mock_user(2, "user2", UserRole.user)
+    user3 = create_mock_user(2, "user3", UserRole.admin)
+
+    def get_user_mocked(id: int):
+        return [ user1, user2, user3][id - 1]
+    repo_service.user_repo.find_by_id.side_effect = get_user_mocked
+    
+    def get_repo_mocked(canonical_name: str):
+        repos = {
+            "user1/python": Repository(),
+            "user2/node": Repository(),
+            "python": Repository(),
+        }
+        return repos.get(canonical_name, None)
+    repo_service.repo_repo.find_by_canonical_name.side_effect = get_repo_mocked
+
+    # [1] Trying to create "user1/python".
+
+    dto = RepositoryCreateDTO(
+        name="python",
+        desc="",
+        public=True,
+        organization_id=None,
+        owner_id=1
+    )
+
+    with pytest.raises(FieldTakenException) as e:
+        repo_service.add(dto)
+
+    # [2] Trying to create "user2/python".
+
+    dto = RepositoryCreateDTO(
+        name="python",
+        desc="",
+        public=True,
+        organization_id=None,
+        owner_id=2
+    )
+
+    repo_res = repo_service.add(dto)
+
+    assert repo_res is not None
+
+    # [3] Trying to create "python"
+    # user is admin, so repo is official.
+
+    dto = RepositoryCreateDTO(
+        name="python",
+        desc="",
+        public=True,
+        organization_id=None,
+        owner_id=3
+    )
+
+    with pytest.raises(FieldTakenException) as e:
+        repo_service.add(dto)

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -5,7 +5,7 @@ import unittest.mock as mock
 from sqlmodel import Session
 
 from app.api.config.security import hash_password
-from app.api.user.user_dto import UserPasswordChangeDTO
+from app.api.user.user_dto import UserPasswordChangeDTO, UserRegisterDTO
 from app.api.user.user_model import User, UserRole
 from app.api.user.user_repo import UserRepo
 from app.api.user.user_service import UserService
@@ -44,8 +44,6 @@ def repo_service(mock_session):
 def create_mock_user(id: int, username: str, role: UserRole):
     return User(id=id, email=f"username@email.com", username=username, role=role, hashed_password=hash_password("1234"))
 
-
-client = TestClient(app)
 
 
 def test_add_repo(repo_service):
@@ -140,3 +138,17 @@ def test_add_repo__repo_name(repo_service):
 
     with pytest.raises(FieldTakenException) as e:
         repo_service.add(dto)
+
+def test_add___integration():
+    with TestClient(app) as client:
+        data = {
+            "username": "u1",
+            "email": "u1@gmail.com",
+            "password": "1234"
+        }
+
+        response = client.post("/api/v1/users/", json=data)
+        print(response.json())
+
+        response = client.post("/api/v1/users/", json=data)
+        print(response.json())

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -146,15 +146,22 @@ def test_add___integration():
             "email": "u1@gmail.com",
             "password": "1234"
         }
-
         response = client.post("/api/v1/users/", json=data)
-        print(response.json())
+        created_user = response.json()
 
-        response = client.post("/api/v1/users/", json=data)
-        print(response.json())
+        data = {
+            "name": "python",
+            "desc": "",
+            "public": True,
+            "organization_id": None,
+            "owner_id": created_user['id'],
+        }
 
-        response = client.get("/api/v1/users/test")
-        print(response.json())
+        response = client.post("/api/v1/repositories/", json=data)
+        created_repo = response.json()
 
-        response = client.get("/api/v1/users/test")
-        print(response.json())
+        assert created_repo['canonical_name'] == f'u1/python'
+        assert created_repo['official'] == False
+
+        response = client.post("/api/v1/repositories/", json=data)
+        assert response.is_client_error

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -152,3 +152,9 @@ def test_add___integration():
 
         response = client.post("/api/v1/users/", json=data)
         print(response.json())
+
+        response = client.get("/api/v1/users/test")
+        print(response.json())
+
+        response = client.get("/api/v1/users/test")
+        print(response.json())

--- a/server/app/tests/test_user.py
+++ b/server/app/tests/test_user.py
@@ -25,39 +25,37 @@ def user_service(mock_session, mock_user_repo):
     return service
 
 def test_change_password(user_service, mock_user_repo):
-    dto = UserPasswordChangeDTO(id=1, old_password="Password1234", new_password="NewPassword1234")
+    dto = UserPasswordChangeDTO(old_password="Password1234", new_password="NewPassword1234")
     user_start = User(id=1, email="a@email.com", username="a", role=UserRole.user, hashed_password=hash_password(dto.old_password))
     user_end = User(id=1, email="a@email.com", username="a", role=UserRole.user, hashed_password=hash_password(dto.new_password))
 
     mock_user_repo.find_by_id.return_value = user_start
     mock_user_repo.change_password.return_value = user_end
 
-    user_result = user_service.change_password(dto)
-
-    assert user_end.hashed_password == user_result.hashed_password
+    user_service.change_password(1, dto) # Should not raise exception.
 
 def test_change_password_no_user(user_service, mock_user_repo):
-    dto = UserPasswordChangeDTO(id=1, old_password="Password1234", new_password="NewPassword1234")
+    dto = UserPasswordChangeDTO(old_password="Password1234", new_password="NewPassword1234")
     mock_user_repo.find_by_id.return_value = None
 
     with pytest.raises(NotFoundException) as e:
-        user_service.change_password(dto)
+        user_service.change_password(1, dto)
     
     assert e.value.entity_type == User
     assert e.value.identifier == 1
 
 def test_change_password_wrong_current_password(user_service, mock_user_repo):
-    dto = UserPasswordChangeDTO(id=1, old_password="Password12345", new_password="NewPassword1234")
+    dto = UserPasswordChangeDTO(old_password="Password12345", new_password="NewPassword1234")
     user_start = User(id=1, email="a@email.com", username="a", role=UserRole.user, hashed_password=hash_password("Password1234"))
     mock_user_repo.find_by_id.return_value = user_start
 
     with pytest.raises(UserException) as e:
-        user_service.change_password(dto)
+        user_service.change_password(1, dto)
 
 def test_change_password_new_password_is_same_as_current_password(user_service, mock_user_repo):
-    dto = UserPasswordChangeDTO(id=1, old_password="Password1234", new_password="Password1234")
-    user_start = User(id=1, email="a@email.com", username="a", role=UserRole.user, hashed_password=hash_password(dto.old_password))
+    dto = UserPasswordChangeDTO(old_password="Password1234", new_password="Password1234")
+    user_start = User(email="a@email.com", username="a", role=UserRole.user, hashed_password=hash_password(dto.old_password))
     mock_user_repo.find_by_id.return_value = user_start
 
     with pytest.raises(UserException) as e:
-        user_service.change_password(dto)
+        user_service.change_password(1, dto)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,3 +11,4 @@ cryptography
 fastapi-cache2[redis]
 
 pytest
+httpx


### PR DESCRIPTION
Closes #9.

Users with roles `user` and `admin` can create repositories after logging in.
The user interface is similar to the one in GitHub.

When creating a repository, you can decide if it belongs to _you_ or any organization that you are a part of. We don't have organizations implemented yet, so that part is a placeholder.

I have added both unit and integration tests. To perform these tests locally, check the README in `server/app/tests`.

The tests are also part of the CI/CD pipeline when creating pull requests to `develop`.