### PR TITLE
Feature view repositories

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -11,6 +11,7 @@ npm i axios
 npm i react-router-dom
 npm i jwt-decode
 npm i buffer
+npm i date-fns
 npm run dev
 ```
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.7",
         "bootstrap": "^5.3.3",
         "buffer": "^6.0.3",
+        "date-fns": "^4.1.0",
         "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.5",
@@ -1993,6 +1994,15 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -4825,6 +4835,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "debug": {
       "version": "4.3.7",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.7.7",
     "bootstrap": "^5.3.3",
     "buffer": "^6.0.3",
+    "date-fns": "^4.1.0",
     "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.5",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -49,7 +49,7 @@ function App() {
                     {authRoute("/logout", [], UserLogout)}
 
                     {authRoute("/:userid/repo", [], RepositoriesOfUser)}
-                    {authRoute("/repo/*", [], RepositoryPage)}
+                    {authRoute("/r/*", [], RepositoryPage)}
 
                     {/* Any role. */}
                     {authRoute("/password-change-required", ['user', 'admin', 'superadmin'], UserPasswordChangeRequired)}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -48,7 +48,7 @@ function App() {
                     {authRoute("/login", [], UserLogin)}
                     {authRoute("/logout", [], UserLogout)}
 
-                    {authRoute("/:userid/repo", [], RepositoriesOfUser)}
+                    {authRoute("/u/:username/repos", [], RepositoriesOfUser)}
                     {authRoute("/r/*", [], RepositoryPage)}
 
                     {/* Any role. */}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import { UserLogout } from './pages/UserLogout';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { OrganizationCreate } from './pages/OrgCreate';
 import { RepositoriesOfUser } from './pages/RepoOfUser';
+import { RepositoryPage } from './pages/RepoPage';
 
 // This function converts:
 //
@@ -48,6 +49,7 @@ function App() {
                     {authRoute("/logout", [], UserLogout)}
 
                     {authRoute("/:userid/repo", [], RepositoriesOfUser)}
+                    {authRoute("/repo/*", [], RepositoryPage)}
 
                     {/* Any role. */}
                     {authRoute("/password-change-required", ['user', 'admin', 'superadmin'], UserPasswordChangeRequired)}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import { BrowserRouter, Route, RouteProps, Routes } from "react-router";
 import { UserLogout } from './pages/UserLogout';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { OrganizationCreate } from './pages/OrgCreate';
+import { RepositoriesOfUser } from './pages/RepoOfUser';
 
 // This function converts:
 //
@@ -45,6 +46,8 @@ function App() {
                     {authRoute("/", [], Home)}
                     {authRoute("/login", [], UserLogin)}
                     {authRoute("/logout", [], UserLogout)}
+
+                    {authRoute("/:userid/repo", [], RepositoriesOfUser)}
 
                     {/* Any role. */}
                     {authRoute("/password-change-required", ['user', 'admin', 'superadmin'], UserPasswordChangeRequired)}

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -26,6 +26,11 @@ export interface ReposOfUserDTO {
     organization_names: { [key: number]: string };
 }
 
+export interface RepoExtDTO extends RepoDTO {
+    owner_name: string,
+    org_name: string | null,
+}
+
 export class RepositoryService {
     static async CreateRepository(dto: RepoCreateDTO): Promise<AxiosResponse<RepoDTO>> {
         return await axiosInstance.post(`/repositories`, dto);
@@ -35,7 +40,7 @@ export class RepositoryService {
         return await axiosInstance.get(`/repositories/u/${user_id}`);
     }
 
-    static async GetRepoByCanonicalName(name: string): Promise<AxiosResponse<RepoDTO>> {
+    static async GetRepoByCanonicalName(name: string): Promise<AxiosResponse<RepoExtDTO>> {
         return await axiosInstance.get(`/repositories/${name}`);
     }
 }

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -19,12 +19,19 @@ export interface RepoDTO {
     organization_id: number | null,
 }
 
+export interface ReposOfUserDTO {
+    user_id: number,
+    user_name: string,
+    repos: RepoDTO[],
+    organization_names: { [key: number]: string };
+}
+
 export class RepositoryService {
     static async CreateRepository(dto: RepoCreateDTO): Promise<AxiosResponse<RepoDTO>> {
         return await axiosInstance.post(`/repositories`, dto);
     }
 
-    static async GetRepositoriesOfUser(user_id: number): Promise<AxiosResponse<RepoDTO[]>> {
+    static async GetRepositoriesOfUser(user_id: number): Promise<AxiosResponse<ReposOfUserDTO>> {
         return await axiosInstance.get(`/repositories/u/${user_id}`);
     }
 }

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -16,12 +16,15 @@ export interface RepoDTO {
     public: boolean,
     official: boolean,
     owner_id: number,
-    organization_id: number,
+    organization_id: number | null,
 }
-
 
 export class RepositoryService {
     static async CreateRepository(dto: RepoCreateDTO): Promise<AxiosResponse<RepoDTO>> {
         return await axiosInstance.post(`/repositories`, dto);
+    }
+
+    static async GetRepositoriesOfUser(user_id: number): Promise<AxiosResponse<RepoDTO[]>> {
+        return await axiosInstance.get(`/repositories/u/${user_id}`);
     }
 }

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -36,9 +36,10 @@ export class RepositoryService {
         return await axiosInstance.post(`/repositories`, dto);
     }
 
-    static async GetRepositoriesOfUser(user_id: number): Promise<AxiosResponse<ReposOfUserDTO>> {
-        return await axiosInstance.get(`/repositories/u/${user_id}`);
+    static async GetRepositoriesOfUser(username: string): Promise<AxiosResponse<ReposOfUserDTO>> {
+        return await axiosInstance.get(`/repositories/u/${username}`);
     }
+
 
     static async GetRepoByCanonicalName(name: string): Promise<AxiosResponse<RepoExtDTO>> {
         return await axiosInstance.get(`/repositories/${name}`);

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -34,4 +34,8 @@ export class RepositoryService {
     static async GetRepositoriesOfUser(user_id: number): Promise<AxiosResponse<ReposOfUserDTO>> {
         return await axiosInstance.get(`/repositories/u/${user_id}`);
     }
+
+    static async GetRepoByCanonicalName(name: string): Promise<AxiosResponse<RepoDTO>> {
+        return await axiosInstance.get(`/repositories/${name}`);
+    }
 }

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -1,6 +1,13 @@
 import { AxiosResponse } from "axios";
 import { axiosInstance } from "../util/http";
 
+export enum RepositoryBadge {
+    none = "none",
+    official = "official",
+    verified = "verified",
+    sponsored_oss = "sponsored_oss",
+}
+
 export interface RepoCreateDTO {
     name: string,
     desc: string,
@@ -14,9 +21,11 @@ export interface RepoDTO {
     canonical_name: string,
     desc: string
     public: boolean,
-    official: boolean,
     owner_id: number,
     organization_id: number | null,
+    badge: RepositoryBadge,
+    last_updated: string, // Encoded Date() object.
+    downloads: number,
 }
 
 export interface ReposOfUserDTO {
@@ -32,6 +41,40 @@ export interface RepoExtDTO extends RepoDTO {
 }
 
 export class RepositoryService {
+    static BadgeToHumanText(badge: RepositoryBadge): string {
+        switch (badge) {
+            case RepositoryBadge.none: return "";
+            case RepositoryBadge.official: return "Official";
+            case RepositoryBadge.verified: return "Verified Publisher";
+            case RepositoryBadge.sponsored_oss: return "Sponsored OSS";
+            default: return `${badge}`;
+        }
+    }
+
+    static BadgeToBootstrapColor(badge: RepositoryBadge): string {
+        switch (badge) {
+            case RepositoryBadge.none: return "bg-light";
+            case RepositoryBadge.official: return "bg-primary";
+            case RepositoryBadge.verified: return "bg-secondary";
+            case RepositoryBadge.sponsored_oss: return "bg-success";
+            default: return `bg-light`;
+        }
+    }
+
+    /**
+     * 
+     * Usage: <i className={`bi ${BadgeToBootstrapIcon(...)}`}></i>
+     */
+    static BadgeToHumanBootstrapIcon(badge: RepositoryBadge): string {
+        switch (badge) {
+            case RepositoryBadge.none: return "";
+            case RepositoryBadge.official: return "bi-award";
+            case RepositoryBadge.verified: return "bi-patch-check-fill";
+            case RepositoryBadge.sponsored_oss: return "bi-git";
+            default: return ``;
+        }
+    }
+
     static async CreateRepository(dto: RepoCreateDTO): Promise<AxiosResponse<RepoDTO>> {
         return await axiosInstance.post(`/repositories`, dto);
     }

--- a/client/src/components/RepoOverview.tsx
+++ b/client/src/components/RepoOverview.tsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+import { RepoDTO } from '../api/repo.api';
+
+export const RepoOverview: React.FC<{ isActive: boolean, repo: RepoDTO }> = (props) => {
+    useEffect(() => {
+        if (props.isActive) {
+            // Tab selected, do stuff here...
+        }
+    }, [props.isActive]);
+
+    return (
+        <div className="tab-pane fade show active" id="overview">
+            <p>{props.repo.desc}</p>
+        </div>
+    );
+};

--- a/client/src/components/RepoTags.tsx
+++ b/client/src/components/RepoTags.tsx
@@ -1,0 +1,15 @@
+import React, { useEffect } from 'react';
+
+export const RepoTags: React.FC<{ isActive: boolean }> = ({ isActive }) => {
+    useEffect(() => {
+        if (isActive) {
+            // Load tags if they haven't been loaded yet.
+        }
+    }, [isActive]);
+
+    return (
+        <div className="tab-pane fade show active" id="tags">
+            <p>Tags...</p>
+        </div>
+    );
+};

--- a/client/src/pages/RepoOfUser.css
+++ b/client/src/pages/RepoOfUser.css
@@ -1,0 +1,8 @@
+.repo-of-user {
+    padding: 20px 27%;
+    border-radius: 10px;
+
+    .moon {
+        color: #f5f5e0;
+    }
+}

--- a/client/src/pages/RepoOfUser.css
+++ b/client/src/pages/RepoOfUser.css
@@ -1,8 +1,4 @@
 .repo-of-user {
     padding: 20px 27%;
     border-radius: 10px;
-
-    .moon {
-        color: #f5f5e0;
-    }
 }

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -170,7 +170,7 @@ export const RepositoriesOfUser: React.FC = () => {
                         <Card.Body>
                             {/* Repository Title with React Router Link */}
                             <Card.Title>
-                                <Link to={`/repo/${repo.canonical_name}`} className="text-primary">
+                                <Link to={`/r/${repo.canonical_name}`} className="text-primary">
                                     <span>{repo.name}</span>
                                 </Link>
                                 {!repo.public && (

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -282,7 +282,7 @@ export const RepositoriesOfUser: React.FC = () => {
                                 {/* Last update */}
                                 {repo.last_updated && (
                                     <Card.Text style={{ fontSize: '0.8rem' }}>
-                                        {formatDistanceToNow(new Date(repo.last_updated), { addSuffix: true })}
+                                        Updated {formatDistanceToNow(new Date(repo.last_updated), { addSuffix: true })}
                                     </Card.Text>
                                 )}
 

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Card, Row, Col, Spinner } from 'react-bootstrap';
+import { RepoDTO, RepositoryService } from '../api/repo.api';
+import { AxiosError, AxiosResponse } from 'axios';
+import './RepoOfUser.css';
+import { getJwtId } from '../util/localstorage';
+
+export const RepositoriesOfUser: React.FC = () => {
+    const [repositories, setRepositories] = useState<RepoDTO[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    const { userid } = useParams<{ userid: string }>();
+    const [myId, setMyId] = useState<number>();
+
+    useEffect(() => {
+        fetchRepos();
+
+        setMyId(getJwtId());
+    }, []);
+
+    const fetchRepos = () => {
+        RepositoryService.GetRepositoriesOfUser(Number.parseInt(userid!)).then((res: AxiosResponse<RepoDTO[]>) => {
+            setLoading(false);
+            setRepositories(res.data);
+
+            console.log(res.data);
+        }).catch((err: AxiosError) => {
+            setError(`${err}`);
+
+            console.error(err);
+        })
+    }
+
+    if (loading) {
+        return (
+            <div className="d-flex justify-content-center align-items-center">
+                <Spinner animation="border" />
+            </div>
+        );
+    }
+
+    if (error) {
+        return <div className="alert alert-danger">{error}</div>;
+    }
+
+    return (
+        <Row className="g-4 repo-of-user">
+            {userid == myId ? (<h1>Your repositories</h1>) : (<h1>{userid}'s repositories</h1>)}
+
+            {repositories.map((repo) => (
+                <Col key={repo.id} xs={12}>
+                    <Card>
+                        <Card.Body>
+                            {/* Repository Title with React Router Link */}
+                            <Card.Title>
+                                <Link to={`/repo/${repo.canonical_name}`} className="text-primary">
+                                    <span>{repo.name}</span>
+                                </Link>
+                                {!repo.public && (
+                                    <span className="badge rounded-pill bg-secondary" style={{ fontSize: '0.7rem', marginLeft: '1em' }}>
+                                        <i className="bi bi-lock"></i>
+                                        Private
+                                    </span>
+                                )}
+                            </Card.Title>
+
+                            {/* Organization Name (if exists) */}
+                            {repo.organization_id && (
+                                <Card.Subtitle className="mb-2 text-muted" style={{ fontSize: '0.8rem' }}>
+                                    Part of organization {repo.organization_id}
+                                </Card.Subtitle>
+                            )}
+
+                            {/* Description */}
+                            {repo.desc && (
+                                <Card.Text style={{ fontSize: '0.9rem' }}>
+                                    {repo.desc}
+                                </Card.Text>
+                            )}
+
+                            {/* Star Count [TODO] */}
+                            {/*repo.stars > 0*/ true && (
+                                <div className="d-flex align-items-center">
+                                    <i className="bi bi-moon moon"></i>
+                                    <span>{17}</span>
+                                    {/* <span>{repo.stars}</span> */}
+                                </div>
+                            )}
+                        </Card.Body>
+                    </Card>
+                </Col>
+            ))}
+        </Row>
+    );
+};

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useLocation, useNavigate, useNavigation, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Card, Row, Col, Spinner, Button } from 'react-bootstrap';
-import { RepoDTO, RepositoryService, ReposOfUserDTO } from '../api/repo.api';
+import { RepoDTO, RepositoryBadge, RepositoryService, ReposOfUserDTO } from '../api/repo.api';
 import { AxiosError, AxiosResponse } from 'axios';
 import './RepoOfUser.css';
 import { getJwtId } from '../util/localstorage';
+import { formatDistanceToNow } from 'date-fns';
 
 export const RepositoriesOfUser: React.FC = () => {
     const [fullResult, setFullResult] = useState<ReposOfUserDTO>();
@@ -22,6 +23,10 @@ export const RepositoriesOfUser: React.FC = () => {
     const [selectedOrg, setSelectedOrg] = useState<number | undefined>(undefined);
     const [showPublic, setShowPublic] = useState(true);
     const [showPrivate, setShowPrivate] = useState(true);
+
+    const [showBadgeOfficial, setShowBadgeOfficial] = useState(true);
+    const [showBadgeVerified, setShowBadgeVerified] = useState(true);
+    const [showBadgeSponsoredOSS, setShowBadgeSponsoredOSS] = useState(true);
 
     let navigate = useNavigate();
 
@@ -64,30 +69,75 @@ export const RepositoriesOfUser: React.FC = () => {
     const handleOrgChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const orgId = Number(e.target.value);
         setSelectedOrg(orgId);
-        filterRepos(searchTerm, orgId, showPublic, showPrivate);
+        filterRepos(searchTerm, orgId, showPublic, showPrivate, showBadgeOfficial, showBadgeVerified, showBadgeSponsoredOSS);
     };
 
     const handlePublicChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setShowPublic(e.target.checked);
-        filterRepos(searchTerm, selectedOrg, e.target.checked, showPrivate);
+        filterRepos(searchTerm, selectedOrg, e.target.checked, showPrivate, showBadgeOfficial, showBadgeVerified, showBadgeSponsoredOSS);
     };
 
     const handlePrivateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setShowPrivate(e.target.checked);
-        filterRepos(searchTerm, selectedOrg, showPublic, e.target.checked);
+        filterRepos(searchTerm, selectedOrg, showPublic, e.target.checked, showBadgeOfficial, showBadgeVerified, showBadgeSponsoredOSS);
     };
 
-    const filterRepos = (searchTerm: string, orgId?: number, showPublic?: boolean, showPrivate?: boolean) => {
+    const handleBadgeOfficialChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setShowBadgeOfficial(e.target.checked);
+        filterRepos(searchTerm, selectedOrg, showPublic, showPrivate, e.target.checked, showBadgeVerified, showBadgeSponsoredOSS);
+    };
+
+    const handleBadgeVerifiedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setShowBadgeVerified(e.target.checked);
+        filterRepos(searchTerm, selectedOrg, showPublic, showPrivate, showBadgeOfficial, e.target.checked, showBadgeSponsoredOSS);
+    };
+
+    const handleBadgeSponsoredOSSChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setShowBadgeSponsoredOSS(e.target.checked);
+        filterRepos(searchTerm, selectedOrg, showPublic, showPrivate, showBadgeOfficial, showBadgeVerified, e.target.checked);
+    };
+
+    const filterRepos = (searchTerm: string, orgId?: number, showPublic?: boolean, showPrivate?: boolean, showBadgeOfficial?: boolean, showBadgeVerified?: boolean, showBadgeSponsoredOSS?: boolean) => {
         let filtered = repositories.filter((repo) => {
             const matchesSearch =
                 repo.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                 (repo.desc && repo.desc.toLowerCase().includes(searchTerm.toLowerCase()));
             const matchesOrg = orgId ? repo.organization_id === orgId : true;
             const matchesVisibility = (showPublic && repo.public) || (showPrivate && !repo.public);
-            return matchesSearch && matchesOrg && matchesVisibility;
+            const matchesBadge =
+                (repo.badge == RepositoryBadge.none)
+                || (repo.badge == RepositoryBadge.official && showBadgeOfficial)
+                || (repo.badge == RepositoryBadge.verified && showBadgeVerified)
+                || (repo.badge == RepositoryBadge.sponsored_oss && showBadgeSponsoredOSS);
+            return matchesSearch && matchesOrg && matchesVisibility && matchesBadge;
         });
         setFilteredRepos(filtered);
     };
+
+    // Respecting DRY.
+    // TODO: `checked` stores reactive state, but `badgeDataBundle` is a regular array,
+    // so this doesn't actually work. However, we filter inside a filter() and the checkboxes
+    // are always in sync, so this sort of works by accident.
+    const badgeDataBundle = [
+        {
+            type: RepositoryBadge.official,
+            checked: showBadgeOfficial,
+            onChange: handleBadgeOfficialChange,
+            id: "officialCheckbox",
+        },
+        {
+            type: RepositoryBadge.verified,
+            checked: showBadgeVerified,
+            onChange: handleBadgeVerifiedChange,
+            id: "verifiedCheckbox",
+        },
+        {
+            type: RepositoryBadge.sponsored_oss,
+            checked: showBadgeSponsoredOSS,
+            onChange: handleBadgeSponsoredOSSChange,
+            id: "sponsoredOSSCeckbox",
+        },
+    ];
 
 
     if (loading) {
@@ -168,52 +218,106 @@ export const RepositoriesOfUser: React.FC = () => {
                             </label>
                         </div>
                     </div>
-                </div>
-            )}
 
-            {filteredRepos.map((repo) => (
-                <Col key={repo.id} xs={12}>
-                    <Card>
-                        <Card.Body>
-                            {/* Repository Title with React Router Link */}
-                            <Card.Title>
-                                <Link to={`/r/${repo.canonical_name}`} className="text-primary">
-                                    <span>{repo.name}</span>
-                                </Link>
-                                {!repo.public && (
-                                    <span className="badge rounded-pill bg-secondary" style={{ fontSize: '0.7rem', marginLeft: '1em' }}>
-                                        <i className="bi bi-lock"></i>
-                                        Private
+                    {/* Badges - Checkbox for each badge type. */}
+                    {badgeDataBundle.map((badge) => (
+                        <div className="mb-3">
+                            <div className="form-check ms-2 d-flex align-items-center">
+                                <input
+                                    type="checkbox"
+                                    className="form-check-input form-check-lg"
+                                    checked={badge.checked}
+                                    onChange={badge.onChange}
+                                    id={badge.id}
+                                />
+                                <label className="form-check-label fs-5 ms-2" htmlFor={badge.id}>
+                                    <span className={`badge rounded-pill ${RepositoryService.BadgeToBootstrapColor(badge.type)}`}>
+                                        <i className={`bi ${RepositoryService.BadgeToHumanBootstrapIcon(badge.type)}`}> </i>
+                                        {RepositoryService.BadgeToHumanText(badge.type)}
                                     </span>
+                                </label>
+                            </div>
+                        </div>
+                    ))}
+                </div >
+            )
+            }
+
+            {
+                filteredRepos.map((repo) => (
+                    <Col key={repo.id} xs={12}>
+                        <Card>
+                            <Card.Body>
+                                {/* Repository Title with React Router Link */}
+                                <Card.Title>
+                                    <Link to={`/r/${repo.canonical_name}`} className="text-primary">
+                                        <span>{repo.name}</span>
+                                    </Link>
+                                    {/* Private */}
+                                    {!repo.public && (
+                                        <span className="badge rounded-pill bg-secondary" style={{ fontSize: '0.7rem', marginLeft: '1em' }}>
+                                            <i className="bi bi-lock"></i>
+                                            Private
+                                        </span>
+                                    )}
+                                    {/* Badge */}
+                                    {repo && repo?.badge !== RepositoryBadge.none &&
+                                        <span
+                                            className={`badge rounded-pill ${RepositoryService.BadgeToBootstrapColor(repo?.badge)}`}
+                                            style={{ fontSize: '0.7rem', marginLeft: '1em' }}
+                                        >
+                                            <i className={`bi ${RepositoryService.BadgeToHumanBootstrapIcon(repo?.badge)}`}> </i>
+                                            {RepositoryService.BadgeToHumanText(repo?.badge)}
+                                        </span>
+                                    }
+                                </Card.Title>
+
+                                {/* Organization Name (if exists) */}
+                                {repo.organization_id && (
+                                    <Card.Subtitle className="mb-2 text-muted" style={{ fontSize: '0.8rem' }}>
+                                        Part of organization {orgNames?.get(repo.organization_id)}
+                                    </Card.Subtitle>
                                 )}
-                            </Card.Title>
 
-                            {/* Organization Name (if exists) */}
-                            {repo.organization_id && (
-                                <Card.Subtitle className="mb-2 text-muted" style={{ fontSize: '0.8rem' }}>
-                                    Part of organization {orgNames?.get(repo.organization_id)}
-                                </Card.Subtitle>
-                            )}
+                                {/* Last update */}
+                                {repo.last_updated && (
+                                    <Card.Text style={{ fontSize: '0.8rem' }}>
+                                        {formatDistanceToNow(new Date(repo.last_updated), { addSuffix: true })}
+                                    </Card.Text>
+                                )}
 
-                            {/* Description */}
-                            {repo.desc && (
-                                <Card.Text style={{ fontSize: '0.9rem' }}>
-                                    {repo.desc}
-                                </Card.Text>
-                            )}
+                                {/* Description */}
+                                {repo.desc && (
+                                    <Card.Text style={{ fontSize: '0.9rem' }}>
+                                        {repo.desc}
+                                    </Card.Text>
+                                )}
 
-                            {/* Star Count [TODO] */}
-                            {/*repo.stars > 0*/ true && (
-                                <div className="d-flex align-items-center">
-                                    <i className="bi bi-moon moon"></i>
-                                    <span>{17}</span>
-                                    {/* <span>{repo.stars}</span> */}
+                                <div className="d-flex">
+                                    {/* Download Count */}
+                                    {
+                                        <span className="align-items-center">
+                                            <i className="bi bi-download"></i>
+                                            <span> {repo.downloads}</span>
+                                        </span>
+                                    }
+
+                                    <i className="bi bi-dot" style={{ marginLeft: '0.2em', marginRight: '0.2em' }}></i>
+
+                                    {/* Star Count [TODO] */}
+                                    {/*repo.stars > 0*/ true && (
+                                        <span className="align-items-center">
+                                            <i className="bi bi-moon moon"></i>
+                                            <span>{17}</span>
+                                            {/* <span>{repo.stars}</span> */}
+                                        </span>
+                                    )}
                                 </div>
-                            )}
-                        </Card.Body>
-                    </Card>
-                </Col>
-            ))}
-        </Row>
+                            </Card.Body>
+                        </Card>
+                    </Col>
+                ))
+            }
+        </Row >
     );
 };

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useNavigation, useParams } from 'react-router-dom';
 import { Card, Row, Col, Spinner, Button } from 'react-bootstrap';
 import { RepoDTO, RepositoryService, ReposOfUserDTO } from '../api/repo.api';
 import { AxiosError, AxiosResponse } from 'axios';
@@ -11,7 +11,7 @@ export const RepositoriesOfUser: React.FC = () => {
     const [orgNames, setOrgNames] = useState<Map<number, string>>();
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
-    const { userid } = useParams<{ userid: string }>();
+    const { username } = useParams<{ username: string }>();
     const [myId, setMyId] = useState<number>();
 
     const [repositories, setRepositories] = useState<RepoDTO[]>([]);
@@ -23,6 +23,8 @@ export const RepositoriesOfUser: React.FC = () => {
     const [showPublic, setShowPublic] = useState(true);
     const [showPrivate, setShowPrivate] = useState(true);
 
+    let navigate = useNavigate();
+
     useEffect(() => {
         fetchRepos();
 
@@ -30,7 +32,12 @@ export const RepositoriesOfUser: React.FC = () => {
     }, []);
 
     const fetchRepos = () => {
-        RepositoryService.GetRepositoriesOfUser(Number.parseInt(userid!)).then((res: AxiosResponse<ReposOfUserDTO>) => {
+        if (username === undefined) {
+            navigate(`/`);
+            return;
+        }
+
+        RepositoryService.GetRepositoriesOfUser(username).then((res: AxiosResponse<ReposOfUserDTO>) => {
             setLoading(false);
             setFullResult(res.data);
             setRepositories(res.data.repos);
@@ -98,7 +105,7 @@ export const RepositoriesOfUser: React.FC = () => {
     return (
         <Row className="g-4 repo-of-user">
             {/* Page Title */}
-            {userid == myId ? (<h1>Your repositories</h1>) : (<h1>{fullResult!.user_name}'s repositories</h1>)}
+            {fullResult?.user_id == myId ? (<h1>Your repositories</h1>) : (<h1>{fullResult!.user_name}'s repositories</h1>)}
 
             <div className="d-flex justify-content-between">
                 {/* Search Bar */}

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { Card, Row, Col, Spinner } from 'react-bootstrap';
+import { Card, Row, Col, Spinner, Button } from 'react-bootstrap';
 import { RepoDTO, RepositoryService, ReposOfUserDTO } from '../api/repo.api';
 import { AxiosError, AxiosResponse } from 'axios';
 import './RepoOfUser.css';
@@ -8,12 +8,20 @@ import { getJwtId } from '../util/localstorage';
 
 export const RepositoriesOfUser: React.FC = () => {
     const [fullResult, setFullResult] = useState<ReposOfUserDTO>();
-    const [repositories, setRepositories] = useState<RepoDTO[]>([]);
     const [orgNames, setOrgNames] = useState<Map<number, string>>();
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
     const { userid } = useParams<{ userid: string }>();
     const [myId, setMyId] = useState<number>();
+
+    const [repositories, setRepositories] = useState<RepoDTO[]>([]);
+    const [filteredRepos, setFilteredRepos] = useState<RepoDTO[]>([]);
+
+    const [searchTerm, setSearchTerm] = useState('');
+    const [showAdvancedSearch, setShowAdvancedSearch] = useState(false);
+    const [selectedOrg, setSelectedOrg] = useState<number | undefined>(undefined);
+    const [showPublic, setShowPublic] = useState(true);
+    const [showPrivate, setShowPrivate] = useState(true);
 
     useEffect(() => {
         fetchRepos();
@@ -30,17 +38,50 @@ export const RepositoriesOfUser: React.FC = () => {
             const orgNamesMap = new Map(Object.entries(res.data.organization_names).map(([key, value]) => [Number(key), value]));
             setOrgNames(orgNamesMap);
 
-            console.log(orgNames);
-            console.log(res.data.organization_names);
-            console.log(typeof (res.data.organization_names));
-
-            console.log(res.data);
+            setRepositories(res.data.repos);
+            setFilteredRepos(res.data.repos);
         }).catch((err: AxiosError) => {
             setError(`${err}`);
-
-            console.error(err);
         })
     }
+
+    const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setSearchTerm(e.target.value);
+        filterRepos(e.target.value, selectedOrg, showPublic, showPrivate);
+    };
+
+    const toggleAdvancedSearch = () => {
+        setShowAdvancedSearch(!showAdvancedSearch);
+    };
+
+    const handleOrgChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const orgId = Number(e.target.value);
+        setSelectedOrg(orgId);
+        filterRepos(searchTerm, orgId, showPublic, showPrivate);
+    };
+
+    const handlePublicChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setShowPublic(e.target.checked);
+        filterRepos(searchTerm, selectedOrg, e.target.checked, showPrivate);
+    };
+
+    const handlePrivateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setShowPrivate(e.target.checked);
+        filterRepos(searchTerm, selectedOrg, showPublic, e.target.checked);
+    };
+
+    const filterRepos = (searchTerm: string, orgId?: number, showPublic?: boolean, showPrivate?: boolean) => {
+        let filtered = repositories.filter((repo) => {
+            const matchesSearch =
+                repo.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                (repo.desc && repo.desc.toLowerCase().includes(searchTerm.toLowerCase()));
+            const matchesOrg = orgId ? repo.organization_id === orgId : true;
+            const matchesVisibility = (showPublic && repo.public) || (showPrivate && !repo.public);
+            return matchesSearch && matchesOrg && matchesVisibility;
+        });
+        setFilteredRepos(filtered);
+    };
+
 
     if (loading) {
         return (
@@ -56,9 +97,74 @@ export const RepositoriesOfUser: React.FC = () => {
 
     return (
         <Row className="g-4 repo-of-user">
+            {/* Page Title */}
             {userid == myId ? (<h1>Your repositories</h1>) : (<h1>{fullResult!.user_name}'s repositories</h1>)}
 
-            {repositories.map((repo) => (
+            <div className="d-flex justify-content-between">
+                {/* Search Bar */}
+                <input
+                    type="text"
+                    className="form-control me-2"
+                    placeholder="Search repositories"
+                    value={searchTerm}
+                    onChange={handleSearchChange}
+                />
+                {/* Advanced Search Button */}
+                <Button className="btn btn-primary" onClick={toggleAdvancedSearch}>
+                    {showAdvancedSearch ? <i className="bi bi-funnel-fill"></i> : <i className="bi bi-funnel"></i>}
+                </Button>
+            </div>
+
+            {/* Advanced Search Section */}
+            {showAdvancedSearch && (
+                <div className="advanced-search">
+                    <div className="mb-1">
+                        <select
+                            id="orgSelect"
+                            className="form-select"
+                            value={selectedOrg || ''}
+                            onChange={handleOrgChange}
+                        >
+                            <option value="">All Organizations</option>
+                            {Array.from(orgNames!.entries()).map(([id, name]) => (
+                                <option key={id} value={id}>
+                                    {name}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    {/* Visibility Filter - Public/Private Checkboxes */}
+                    <div className="mb-3">
+                        <div className="form-check ms-2 d-flex align-items-center">
+                            <input
+                                type="checkbox"
+                                className="form-check-input form-check-lg"
+                                checked={showPublic}
+                                onChange={handlePublicChange}
+                                id="publicCheckbox"
+                            />
+                            <label className="form-check-label fs-5 ms-2" htmlFor="publicCheckbox">
+                                <i className="bi bi-journal-bookmark"></i> <b>Public</b>
+                            </label>
+                        </div>
+                        <div className="form-check ms-2 d-flex align-items-center">
+                            <input
+                                type="checkbox"
+                                className="form-check-input form-check-lg"
+                                checked={showPrivate}
+                                onChange={handlePrivateChange}
+                                id="privateCheckbox"
+                            />
+                            <label className="form-check-label fs-5 ms-2" htmlFor="privateCheckbox">
+                                <i className="bi bi-lock"></i> <b>Private</b>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {filteredRepos.map((repo) => (
                 <Col key={repo.id} xs={12}>
                     <Card>
                         <Card.Body>

--- a/client/src/pages/RepoPage.css
+++ b/client/src/pages/RepoPage.css
@@ -2,10 +2,6 @@
     padding: 5px;
     border-radius: 10px;
 
-    .moon {
-        color: #f5f5e0;
-    }
-
     .repo-page-header {
         padding: 20px 27%;
     }

--- a/client/src/pages/RepoPage.css
+++ b/client/src/pages/RepoPage.css
@@ -1,0 +1,12 @@
+.repo-page {
+    padding: 5px;
+    border-radius: 10px;
+
+    .moon {
+        color: #f5f5e0;
+    }
+
+    .repo-page-header {
+        padding: 20px 27%;
+    }
+}

--- a/client/src/pages/RepoPage.tsx
+++ b/client/src/pages/RepoPage.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { Nav, Spinner, Tab } from 'react-bootstrap';
+import { RepoOverview } from '../components/RepoOverview';
+import { RepoTags } from '../components/RepoTags';
+import { NavLink, useParams } from 'react-router-dom';
+import { RepoDTO, RepositoryService } from '../api/repo.api';
+import { AxiosError, AxiosResponse } from 'axios';
+import "./RepoPage.css";
+
+interface RepoOwner {
+    name: string,
+    id: number,
+    isUser: boolean,
+    official: boolean,
+    linkURL: string
+}
+
+export const RepositoryPage: React.FC = () => {
+    const { "*": repoName } = useParams();
+    const [repo, setRepo] = useState<RepoDTO>();
+    const [key, setKey] = useState<string>('overview');
+    const [loading, setLoading] = useState<boolean>(true);
+    const [repoOwner, setRepoOwner] = useState<RepoOwner>({
+        name: '...',
+        id: 1,
+        isUser: true,
+        official: false,
+        linkURL: "."
+    });
+
+    useEffect(() => {
+        RepositoryService.GetRepoByCanonicalName(repoName!).then((res: AxiosResponse<RepoDTO>) => {
+            setRepo(res.data);
+            setLoading(false);
+
+            if (res.data.organization_id === null) {
+                // setRepoOwner({
+                //     res.data.owner_id,
+                //     "",
+                //     true
+                // });
+            }
+
+        }).catch((err: AxiosError) => {
+            if (err.response?.status == 404) {
+                console.error("Not found");
+            } else {
+                console.error(err);
+            }
+        });
+    }, []);
+
+    if (loading) {
+        return (
+            <div className="d-flex justify-content-center align-items-center">
+                <Spinner animation="border" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="repo-page">
+            {/* Repository Section */}
+            <div className="repo-page-header mb-4">
+                <h1>{repo?.canonical_name}</h1>
+                <h5>By <NavLink to={repoOwner.linkURL}>{repoOwner.name}</NavLink></h5>
+                {/* TODO: Star count */}
+                <p>
+                    <i className="bi bi-moon moon"></i><span>{44}</span>
+                </p>
+            </div>
+
+            {/* Tabs Section */}
+            <Tab.Container activeKey={key} onSelect={(k) => setKey(k!)} id="tabs">
+                <Nav variant="tabs" className="mb-3">
+                    <Nav.Item>
+                        <Nav.Link eventKey="overview" className={key === 'overview' ? 'active' : ''}>
+                            Overview
+                        </Nav.Link>
+                    </Nav.Item>
+                    <Nav.Item>
+                        <Nav.Link eventKey="tags" className={key === 'tags' ? 'active' : ''}>
+                            Tags
+                        </Nav.Link>
+                    </Nav.Item>
+                </Nav>
+
+                <Tab.Content>
+                    <Tab.Pane eventKey="overview">
+                        {repo && <RepoOverview isActive={key === 'overview'} repo={repo} />}
+                    </Tab.Pane>
+                    <Tab.Pane eventKey="tags">
+                        <RepoTags isActive={key === 'tags'} />
+                    </Tab.Pane>
+                </Tab.Content>
+            </Tab.Container>
+        </div>
+    );
+};

--- a/client/src/pages/RepoPage.tsx
+++ b/client/src/pages/RepoPage.tsx
@@ -3,15 +3,16 @@ import { Nav, Spinner, Tab } from 'react-bootstrap';
 import { RepoOverview } from '../components/RepoOverview';
 import { RepoTags } from '../components/RepoTags';
 import { NavLink, useNavigate, useParams } from 'react-router-dom';
-import { RepoExtDTO, RepositoryService } from '../api/repo.api';
+import { RepoExtDTO, RepositoryBadge, RepositoryService } from '../api/repo.api';
 import { AxiosError, AxiosResponse } from 'axios';
 import "./RepoPage.css";
+import { formatDistanceToNow } from 'date-fns';
 
 interface RepoOwner {
     name: string,
     id: number,
     isUser: boolean,
-    official: boolean,
+    badge: RepositoryBadge,
     linkURL: string
 }
 
@@ -25,7 +26,7 @@ export const RepositoryPage: React.FC = () => {
         name: '...',
         id: 1,
         isUser: true,
-        official: false,
+        badge: RepositoryBadge.none,
         linkURL: "."
     });
 
@@ -37,7 +38,7 @@ export const RepositoryPage: React.FC = () => {
                 name: res.data.org_name === null ? res.data.owner_name : res.data.org_name,
                 id: res.data.organization_id === null ? res.data.owner_id : res.data.organization_id,
                 isUser: res.data.organization_id === null,
-                official: res.data.official,
+                badge: res.data.badge,
                 linkURL: res.data.org_name === null ? `/u/${res.data.owner_name}/repos` : `/o/${res.data.org_name}`
             });
         }).catch((err: AxiosError) => {
@@ -64,11 +65,14 @@ export const RepositoryPage: React.FC = () => {
             <div className="repo-page-header mb-4">
                 <h1>
                     {repo?.canonical_name}
-                    {/* Official badge */}
-                    {repo?.official &&
-                        <span className="badge rounded-pill bg-primary" style={{ fontSize: '0.5em', marginLeft: '1em' }}>
-                            <i className="bi bi bi-award-fill"></i>
-                            Official
+                    {/* Badge */}
+                    {repo && repo?.badge !== RepositoryBadge.none &&
+                        <span
+                            className={`badge rounded-pill ${RepositoryService.BadgeToBootstrapColor(repo?.badge)}`}
+                            style={{ fontSize: '0.5em', marginLeft: '0.5em' }}
+                        >
+                            <i className={`bi ${RepositoryService.BadgeToHumanBootstrapIcon(repo?.badge)}`}> </i>
+                            {RepositoryService.BadgeToHumanText(repo?.badge)}
                         </span>
                     }
                     {/* Private badge */}
@@ -82,10 +86,35 @@ export const RepositoryPage: React.FC = () => {
                 <h5>
                     {repoOwner.isUser ? <>By </> : <>Part of </>}
                     <NavLink to={repoOwner.linkURL}>{repoOwner.name}</NavLink>
+
+                    <i className="bi bi-dot" style={{ marginLeft: '0.2em', marginRight: '0.2em' }}></i>
+
+                    {/* Last update */}
+                    {repo && repo.last_updated && (
+                        <>
+                            Updated {formatDistanceToNow(new Date(repo.last_updated), { addSuffix: true })}
+                        </>
+                    )}
                 </h5>
-                {/* TODO: Star count */}
-                <p>
-                    <i className="bi bi-moon moon"></i><span>{44}</span>
+
+                <p className="d-flex">
+                    {/* Download Count */}
+                    {
+                        <span className="align-items-center">
+                            <i className="bi bi-download"></i>
+                            <span> {repo?.downloads}</span>
+                        </span>
+                    }
+
+                    <i className="bi bi-dot" style={{ marginLeft: '0.2em', marginRight: '0.2em' }}></i>
+
+                    {/* Star Count [TODO] */}
+                    {/*repo.stars > 0*/ true && (
+                        <span className="align-items-center">
+                            <i className="bi bi-moon moon"></i>
+                            <span>{17}</span>
+                        </span>
+                    )}
                 </p>
             </div>
 

--- a/client/src/pages/RepoPage.tsx
+++ b/client/src/pages/RepoPage.tsx
@@ -38,7 +38,7 @@ export const RepositoryPage: React.FC = () => {
                 id: res.data.organization_id === null ? res.data.owner_id : res.data.organization_id,
                 isUser: res.data.organization_id === null,
                 official: res.data.official,
-                linkURL: res.data.org_name === null ? `/u/${res.data.owner_name}` : `/o/${res.data.org_name}`
+                linkURL: res.data.org_name === null ? `/u/${res.data.owner_name}/repos` : `/o/${res.data.org_name}`
             });
         }).catch((err: AxiosError) => {
             if (err.response?.status == 404) {

--- a/client/src/pages/RepoPage.tsx
+++ b/client/src/pages/RepoPage.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Nav, Spinner, Tab } from 'react-bootstrap';
 import { RepoOverview } from '../components/RepoOverview';
 import { RepoTags } from '../components/RepoTags';
-import { NavLink, useParams } from 'react-router-dom';
-import { RepoDTO, RepositoryService } from '../api/repo.api';
+import { NavLink, useNavigate, useParams } from 'react-router-dom';
+import { RepoExtDTO, RepositoryService } from '../api/repo.api';
 import { AxiosError, AxiosResponse } from 'axios';
 import "./RepoPage.css";
 
@@ -17,9 +17,10 @@ interface RepoOwner {
 
 export const RepositoryPage: React.FC = () => {
     const { "*": repoName } = useParams();
-    const [repo, setRepo] = useState<RepoDTO>();
+    const [repo, setRepo] = useState<RepoExtDTO>();
     const [key, setKey] = useState<string>('overview');
     const [loading, setLoading] = useState<boolean>(true);
+    let navigate = useNavigate();
     const [repoOwner, setRepoOwner] = useState<RepoOwner>({
         name: '...',
         id: 1,
@@ -29,21 +30,20 @@ export const RepositoryPage: React.FC = () => {
     });
 
     useEffect(() => {
-        RepositoryService.GetRepoByCanonicalName(repoName!).then((res: AxiosResponse<RepoDTO>) => {
-            setRepo(res.data);
+        RepositoryService.GetRepoByCanonicalName(repoName!).then((res: AxiosResponse<RepoExtDTO>) => {
             setLoading(false);
-
-            if (res.data.organization_id === null) {
-                // setRepoOwner({
-                //     res.data.owner_id,
-                //     "",
-                //     true
-                // });
-            }
-
+            setRepo(res.data);
+            setRepoOwner({
+                name: res.data.org_name === null ? res.data.owner_name : res.data.org_name,
+                id: res.data.organization_id === null ? res.data.owner_id : res.data.organization_id,
+                isUser: res.data.organization_id === null,
+                official: res.data.official,
+                linkURL: res.data.org_name === null ? `/u/${res.data.owner_name}` : `/o/${res.data.org_name}`
+            });
         }).catch((err: AxiosError) => {
             if (err.response?.status == 404) {
-                console.error("Not found");
+                navigate("/");
+                console.error("Not found - either a typo or access denied.");
             } else {
                 console.error(err);
             }
@@ -62,8 +62,27 @@ export const RepositoryPage: React.FC = () => {
         <div className="repo-page">
             {/* Repository Section */}
             <div className="repo-page-header mb-4">
-                <h1>{repo?.canonical_name}</h1>
-                <h5>By <NavLink to={repoOwner.linkURL}>{repoOwner.name}</NavLink></h5>
+                <h1>
+                    {repo?.canonical_name}
+                    {/* Official badge */}
+                    {repo?.official &&
+                        <span className="badge rounded-pill bg-primary" style={{ fontSize: '0.5em', marginLeft: '1em' }}>
+                            <i className="bi bi bi-award-fill"></i>
+                            Official
+                        </span>
+                    }
+                    {/* Private badge */}
+                    {!repo?.public &&
+                        <span className="badge rounded-pill bg-secondary" style={{ fontSize: '0.5em', marginLeft: '0.5em' }}>
+                            <i className="bi bi-lock"></i>
+                            Private
+                        </span>
+                    }
+                </h1>
+                <h5>
+                    {repoOwner.isUser ? <>By </> : <>Part of </>}
+                    <NavLink to={repoOwner.linkURL}>{repoOwner.name}</NavLink>
+                </h5>
                 {/* TODO: Star count */}
                 <p>
                     <i className="bi bi-moon moon"></i><span>{44}</span>

--- a/client/src/pages/UserLogin.tsx
+++ b/client/src/pages/UserLogin.tsx
@@ -4,7 +4,7 @@ import './UserLogin.css';
 import { TokenDTO, UserLoginDTO, UserService } from '../api/user.api';
 import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
-import { getJwtId, getJwtMustChangePassword, getJwtRole, setJWT } from '../util/localstorage';
+import { getJwtId, getJwtMustChangePassword, getJwtRole, getJwtUsername, setJWT } from '../util/localstorage';
 import { useAuthStore } from '../util/store';
 
 export const UserLogin = () => {
@@ -45,8 +45,8 @@ export const UserLogin = () => {
                 if (getJwtMustChangePassword()) {
                     navigate("/password-change-required");
                 } else {
-                    const id = getJwtId();
-                    navigate(`/${id}/repo`);
+                    const username = getJwtUsername();
+                    navigate(`/u/${username}/repos`);
                 }
             });
         }).catch((err: AxiosError) => {

--- a/client/src/pages/UserLogin.tsx
+++ b/client/src/pages/UserLogin.tsx
@@ -4,7 +4,7 @@ import './UserLogin.css';
 import { TokenDTO, UserLoginDTO, UserService } from '../api/user.api';
 import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
-import { getJwtMustChangePassword, getJwtRole, setJWT } from '../util/localstorage';
+import { getJwtId, getJwtMustChangePassword, getJwtRole, setJWT } from '../util/localstorage';
 import { useAuthStore } from '../util/store';
 
 export const UserLogin = () => {
@@ -45,7 +45,8 @@ export const UserLogin = () => {
                 if (getJwtMustChangePassword()) {
                     navigate("/password-change-required");
                 } else {
-                    navigate("/new");
+                    const id = getJwtId();
+                    navigate(`/${id}/repo`);
                 }
             });
         }).catch((err: AxiosError) => {

--- a/client/src/util/localstorage.ts
+++ b/client/src/util/localstorage.ts
@@ -3,6 +3,7 @@ import { Buffer } from 'buffer';
 export interface JWTStruct {
     id: number,
     role: string,
+    sub: string,
     must_change_password: boolean
 };
 
@@ -35,13 +36,13 @@ export function getJwtRole(): string {
     return getJWT(jwtString).role;
 }
 
-// export function getJwtUsername(): string {
-//     const jwtString = getJWTStringOrNull();
-//     if (jwtString == null) {
-//         return "";
-//     }
-//     return getJWT(jwtString).sub;
-// }
+export function getJwtUsername(): string {
+    const jwtString = getJWTStringOrNull();
+    if (jwtString == null) {
+        return "";
+    }
+    return getJWT(jwtString).sub;
+}
 
 export function getJwtMustChangePassword(): boolean {
     const jwtString = getJWTStringOrNull();

--- a/server/app/api/config/auth.py
+++ b/server/app/api/config/auth.py
@@ -105,6 +105,18 @@ def get_role_from_jwt(jwt: JWTDep):
 def get_id_from_jwt(jwt: JWTDep):
     return decode_jwt(jwt)["id"]
 
+
+def get_id_from_jwt_optional(jwt: JWTDepOptional) -> int | None:
+    """
+    Returns the user ID from the JWT or None if there is no JWT.
+    Use this only when the JWT is optional. Otherwise, use `get_id_from_jwt`. 
+    """
+    try:
+        return get_id_from_jwt(jwt)
+    except:
+        return None
+
+
 def validate_jwt_or_raise_exceptions(jwt: JWTDep, expected_roles: List[str] | List[UserRole] | None, ignore_password_change_requirement: bool):
     token = decode_jwt(jwt)
 

--- a/server/app/api/config/auth.py
+++ b/server/app/api/config/auth.py
@@ -89,6 +89,7 @@ def sign_jwt(user: User) -> str:
     payload = {
         "id": user.id,
         "role": user.role.value,
+        "sub": user.username,
         "must_change_password": user.must_change_password,
     }
     return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
@@ -104,6 +105,10 @@ def get_role_from_jwt(jwt: JWTDep):
 
 def get_id_from_jwt(jwt: JWTDep):
     return decode_jwt(jwt)["id"]
+
+
+def get_username_from_jwt(jwt: JWTDep):
+    return decode_jwt(jwt)["sub"]
 
 
 def get_id_from_jwt_optional(jwt: JWTDepOptional) -> int | None:

--- a/server/app/api/config/exception_handler.py
+++ b/server/app/api/config/exception_handler.py
@@ -33,6 +33,10 @@ class AccessDeniedException(UserException):
 
 
 def register_exception_handler(app: FastAPI):
+    @app.exception_handler(NotFoundException)
+    def _NotFoundException(r: Request, e: NotFoundException):
+        raise HTTPException(404, detail={"message": str(e)}) 
+    
     @app.exception_handler(UserException)
     def _UserException(r: Request, e: UserException):
         raise HTTPException(400, detail={"message": str(e)}) 

--- a/server/app/api/config/exception_handler.py
+++ b/server/app/api/config/exception_handler.py
@@ -22,6 +22,14 @@ class NotFoundException(UserException):
 
     def __str__(self):
         return self.message
+    
+
+class AccessDeniedException(UserException):
+    def __init__(self, msg: str):
+        self.message = f"{msg}"
+
+    def __str__(self):
+        return self.message
 
 
 def register_exception_handler(app: FastAPI):

--- a/server/app/api/config/initialize.py
+++ b/server/app/api/config/initialize.py
@@ -60,6 +60,8 @@ def init_dummy_data():
     repo_service = RepositoryService(session)
     org_service = OrganizationService(session)
 
+    admin1 = user_service.add_admin(UserRegisterDTO(username="admin1", email="admin1@test.com", password="1234"))
+
     user1 = user_service.add(UserRegisterDTO(username="user1", email="user1@test.com", password="1234"))
     user2 = user_service.add(UserRegisterDTO(username="user2", email="user2@test.com", password="1234"))
     user3 = user_service.add(UserRegisterDTO(username="user3", email="user3@test.com", password="1234"))
@@ -73,14 +75,15 @@ def init_dummy_data():
 
     org_service.add_user_to_org(org_id=org1.id, user_id=user2.id)
 
-    repo1 = repo_service.add(user1.id, RepositoryCreateDTO(name="python", desc="Python3 docker image!", public=True, organization_id=None))
-    repo2 = repo_service.add(user1.id, RepositoryCreateDTO(name="node", desc="NodeJS docker image!!!!", public=False, organization_id=None))
-    repo3 = repo_service.add(user1.id, RepositoryCreateDTO(name="dsa", desc="DSA... what could it be?", public=True, organization_id=org1.id))
-    repo4 = repo_service.add(user1.id, RepositoryCreateDTO(name="mio", desc="Mio's... nothing at all", public=False, organization_id=org1.id))
-    repo5 = repo_service.add(user2.id, RepositoryCreateDTO(name="dsa-ui", desc="Just a temp repo....", public=True, organization_id=org1.id))
-    repo6 = repo_service.add(user2.id, RepositoryCreateDTO(name="istrue", desc="istrue e repo o algo", public=True, organization_id=org2.id))
-    repo7 = repo_service.add(user3.id, RepositoryCreateDTO(name="redis", desc="The best NoSQL DB!!!!", public=True, organization_id=None))
-    repo8 = repo_service.add(user4.id, RepositoryCreateDTO(name="redis", desc="The worst NoSQL DB!!!", public=True, organization_id=None))
+    repo1 = repo_service.add(admin1.id, RepositoryCreateDTO(name="python", desc="Official Python Image", public=True, organization_id=None))
+    repo2 = repo_service.add(user1.id, RepositoryCreateDTO(name="python", desc="Python3 docker image!", public=True, organization_id=None))
+    repo3 = repo_service.add(user1.id, RepositoryCreateDTO(name="node", desc="NodeJS docker image!!!!", public=False, organization_id=None))
+    repo4 = repo_service.add(user1.id, RepositoryCreateDTO(name="dsa", desc="DSA... what could it be?", public=True, organization_id=org1.id))
+    repo5 = repo_service.add(user1.id, RepositoryCreateDTO(name="mio", desc="Mio's... nothing at all", public=False, organization_id=org1.id))
+    repo6 = repo_service.add(user2.id, RepositoryCreateDTO(name="dsa-ui", desc="Just a temp repo....", public=True, organization_id=org1.id))
+    repo7 = repo_service.add(user2.id, RepositoryCreateDTO(name="istrue", desc="istrue e repo o algo", public=True, organization_id=org2.id))
+    repo8 = repo_service.add(user3.id, RepositoryCreateDTO(name="redis", desc="The best NoSQL DB!!!!", public=True, organization_id=None))
+    repo9 = repo_service.add(user4.id, RepositoryCreateDTO(name="redis", desc="The worst NoSQL DB!!!", public=True, organization_id=None))
 
     
     print("Finished adding dummy data.")

--- a/server/app/api/config/initialize.py
+++ b/server/app/api/config/initialize.py
@@ -71,6 +71,8 @@ def init_dummy_data():
     org2 = org_service.add(user2.id, OrganizationCreateDTO(name="org2", desc="", image=None))
     org3 = org_service.add(user1.id, OrganizationCreateDTO(name="org3", desc="", image=None))
 
+    org_service.add_user_to_org(org_id=org1.id, user_id=user2.id)
+
     repo1 = repo_service.add(user1.id, RepositoryCreateDTO(name="python", desc="", public=True, organization_id=None))
     repo2 = repo_service.add(user1.id, RepositoryCreateDTO(name="node", desc="", public=True, organization_id=None))
     repo3 = repo_service.add(user1.id, RepositoryCreateDTO(name="dsa", desc="", public=True, organization_id=org1.id))
@@ -79,5 +81,6 @@ def init_dummy_data():
     repo6 = repo_service.add(user2.id, RepositoryCreateDTO(name="istrue", desc="", public=True, organization_id=org2.id))
     repo7 = repo_service.add(user3.id, RepositoryCreateDTO(name="redis", desc="", public=True, organization_id=None))
     repo8 = repo_service.add(user4.id, RepositoryCreateDTO(name="redis", desc="", public=True, organization_id=None))
+
     
     print("Finished adding dummy data.")

--- a/server/app/api/config/initialize.py
+++ b/server/app/api/config/initialize.py
@@ -73,14 +73,14 @@ def init_dummy_data():
 
     org_service.add_user_to_org(org_id=org1.id, user_id=user2.id)
 
-    repo1 = repo_service.add(user1.id, RepositoryCreateDTO(name="python", desc="", public=True, organization_id=None))
-    repo2 = repo_service.add(user1.id, RepositoryCreateDTO(name="node", desc="", public=False, organization_id=None))
-    repo3 = repo_service.add(user1.id, RepositoryCreateDTO(name="dsa", desc="", public=True, organization_id=org1.id))
-    repo4 = repo_service.add(user1.id, RepositoryCreateDTO(name="mio", desc="", public=False, organization_id=org1.id))
-    repo5 = repo_service.add(user2.id, RepositoryCreateDTO(name="dsa-ui", desc="", public=True, organization_id=org1.id))
-    repo6 = repo_service.add(user2.id, RepositoryCreateDTO(name="istrue", desc="", public=True, organization_id=org2.id))
-    repo7 = repo_service.add(user3.id, RepositoryCreateDTO(name="redis", desc="", public=True, organization_id=None))
-    repo8 = repo_service.add(user4.id, RepositoryCreateDTO(name="redis", desc="", public=True, organization_id=None))
+    repo1 = repo_service.add(user1.id, RepositoryCreateDTO(name="python", desc="Python3 docker image!", public=True, organization_id=None))
+    repo2 = repo_service.add(user1.id, RepositoryCreateDTO(name="node", desc="NodeJS docker image!!!!", public=False, organization_id=None))
+    repo3 = repo_service.add(user1.id, RepositoryCreateDTO(name="dsa", desc="DSA... what could it be?", public=True, organization_id=org1.id))
+    repo4 = repo_service.add(user1.id, RepositoryCreateDTO(name="mio", desc="Mio's... nothing at all", public=False, organization_id=org1.id))
+    repo5 = repo_service.add(user2.id, RepositoryCreateDTO(name="dsa-ui", desc="Just a temp repo....", public=True, organization_id=org1.id))
+    repo6 = repo_service.add(user2.id, RepositoryCreateDTO(name="istrue", desc="istrue e repo o algo", public=True, organization_id=org2.id))
+    repo7 = repo_service.add(user3.id, RepositoryCreateDTO(name="redis", desc="The best NoSQL DB!!!!", public=True, organization_id=None))
+    repo8 = repo_service.add(user4.id, RepositoryCreateDTO(name="redis", desc="The worst NoSQL DB!!!", public=True, organization_id=None))
 
     
     print("Finished adding dummy data.")

--- a/server/app/api/config/initialize.py
+++ b/server/app/api/config/initialize.py
@@ -74,9 +74,9 @@ def init_dummy_data():
     org_service.add_user_to_org(org_id=org1.id, user_id=user2.id)
 
     repo1 = repo_service.add(user1.id, RepositoryCreateDTO(name="python", desc="", public=True, organization_id=None))
-    repo2 = repo_service.add(user1.id, RepositoryCreateDTO(name="node", desc="", public=True, organization_id=None))
+    repo2 = repo_service.add(user1.id, RepositoryCreateDTO(name="node", desc="", public=False, organization_id=None))
     repo3 = repo_service.add(user1.id, RepositoryCreateDTO(name="dsa", desc="", public=True, organization_id=org1.id))
-    repo4 = repo_service.add(user1.id, RepositoryCreateDTO(name="mio", desc="", public=True, organization_id=org1.id))
+    repo4 = repo_service.add(user1.id, RepositoryCreateDTO(name="mio", desc="", public=False, organization_id=org1.id))
     repo5 = repo_service.add(user2.id, RepositoryCreateDTO(name="dsa-ui", desc="", public=True, organization_id=org1.id))
     repo6 = repo_service.add(user2.id, RepositoryCreateDTO(name="istrue", desc="", public=True, organization_id=org2.id))
     repo7 = repo_service.add(user3.id, RepositoryCreateDTO(name="redis", desc="", public=True, organization_id=None))

--- a/server/app/api/org/org_model.py
+++ b/server/app/api/org/org_model.py
@@ -1,6 +1,6 @@
 from sqlmodel import Field, Relationship, SQLModel
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 if TYPE_CHECKING:
     from app.api.repo.repo_model import Repository
     from app.api.user.user_model import User
@@ -11,6 +11,9 @@ class OrganizationMembers(SQLModel, table=True):
 
     user_id: int | None = Field(default=None, foreign_key="user.id", primary_key=True)
     organization_id: int | None = Field(default=None, foreign_key="organization.id", primary_key=True)
+
+    organization: "Organization" = Relationship(back_populates="members")
+    user: "User" = Relationship()
 
 
 class Organization(SQLModel, table=True):
@@ -24,3 +27,4 @@ class Organization(SQLModel, table=True):
     owner: "User" = Relationship()
 
     repositories: list["Repository"] = Relationship(back_populates="organization", cascade_delete=True)
+    members: List["OrganizationMembers"] = Relationship(back_populates="organization")

--- a/server/app/api/org/org_repo.py
+++ b/server/app/api/org/org_repo.py
@@ -27,6 +27,14 @@ class OrganizationRepo:
         self.session.commit()
         self.session.refresh(orgmember)
         return orgmember
+    
+    def user_is_in_org(self, user_id: int, org_id: int) -> bool:
+        query = (
+            select(OrganizationMembers)
+            .where(OrganizationMembers.user_id == user_id)
+            .where(OrganizationMembers.organization_id == org_id)
+        )
+        return self.session.exec(query).first() is not None
 
     def find_orgs_that_user_is_member_of(self, user_id: int) -> List[Organization]:
         return self.session.exec(

--- a/server/app/api/org/org_repo.py
+++ b/server/app/api/org/org_repo.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List
 from sqlmodel import Session, select
 from app.api.org.org_model import Organization, OrganizationMembers
 from app.api.repo.repo_model import Repository
@@ -42,3 +42,8 @@ class OrganizationRepo:
             .join(OrganizationMembers, Organization.id == OrganizationMembers.organization_id)
             .where(OrganizationMembers.user_id == user_id)
         ).all()
+    
+    def find_orgs_by_ids(self, ids: list[int]) -> Dict[int, str]:
+        query = select(Organization.id, Organization.name).where(Organization.id.in_(ids))
+        result = self.session.exec(query).all()
+        return {org.id: org.name for org in result}

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List
 from fastapi import Depends
 from sqlmodel import Session
 from app.api.config.database import get_database
@@ -71,6 +71,9 @@ class OrganizationService:
     
     def find_orgs_that_user_is_member_of(self, user_id: int) -> List[Organization]:
         return self.org_repo.find_orgs_that_user_is_member_of(user_id)
+    
+    def find_org_names_by_ids(self, ids: List[int]) -> Dict[int, str]:
+        return self.org_repo.find_orgs_by_ids(ids)
 
 
 def get_org_service(session: Session = Depends(get_database)) -> OrganizationService:

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -20,15 +20,18 @@ def register_repo(jwt: JWTDep, dto: RepositoryCreateDTO, repo_service: Repositor
     repo = repo_service.add(user_id, dto)
     return repo
 
-@router.get("/u/{user_id}", response_model=ReposOfUserDTO, status_code=200, summary="Get repositories of suer")
+@router.get("/u/{username}", response_model=ReposOfUserDTO, status_code=200, summary="Get repositories of suer")
 def get_repositories_of_user(
     jwt: JWTDepOptional, 
-    user_id: int, 
+    username: str, 
     repo_service: RepositoryService = Depends(get_repo_service), 
     user_service: UserService = Depends(get_user_service),
     org_service: OrganizationService = Depends(get_org_service)
 ):
     me_id = get_id_from_jwt_optional(jwt)
+
+    user = user_service.find_by_username(username)
+    user_id = user.id
 
     # NOTE: I had to convert Repository -> RepositoryDTO manually here,
     # because FastAPI does automatic conversion ONLY if the DTO is the

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -1,11 +1,13 @@
 from typing import List
 from fastapi import APIRouter, Depends
 
-from app.api.repo.repo_dto import RepositoryCreateDTO, RepositoryDTO
+from app.api.repo.repo_dto import ReposOfUserDTO, RepositoryCreateDTO, RepositoryDTO
 from app.api.repo.repo_service import RepositoryService, get_repo_service
 from app.api.config.auth import get_id_from_jwt, pre_authorize
 from app.api.user.user_model import UserRole
 from app.api.config.auth import JWTBearer, JWTDep, JWTDepOptional
+from app.api.user.user_service import UserService, get_user_service
+from app.api.org.org_service import OrganizationService, get_org_service
 
 router = APIRouter(prefix="/repositories", tags=["repositories"])
 
@@ -16,11 +18,27 @@ def register_repo(jwt: JWTDep, dto: RepositoryCreateDTO, repo_service: Repositor
     repo = repo_service.add(user_id, dto)
     return repo
 
-@router.get("/u/{user_id}", response_model=List[RepositoryDTO], status_code=200, summary="Get repositories of suer")
-def get_repositories_of_user(jwt: JWTDepOptional, user_id: int, repo_service: RepositoryService = Depends(get_repo_service)):
+@router.get("/u/{user_id}", response_model=ReposOfUserDTO, status_code=200, summary="Get repositories of suer")
+def get_repositories_of_user(
+    jwt: JWTDepOptional, 
+    user_id: int, 
+    repo_service: RepositoryService = Depends(get_repo_service), 
+    user_service: UserService = Depends(get_user_service),
+    org_service: OrganizationService = Depends(get_org_service)
+):
     me_id = None
     try: 
         me_id = get_id_from_jwt(jwt)
     except: ...
 
-    return repo_service.get_repositories_of_user(user_id, me_id)
+    # NOTE: I had to convert Repository -> RepositoryDTO manually here,
+    # because FastAPI does automatic conversion ONLY if the DTO is the
+    # response_model (@router.get(..., response_model=...)). If the DTO
+    # is nested, it won't work.
+    repos = repo_service.get_repositories_of_user(user_id, me_id)
+    repos = [RepositoryDTO.model_validate(repo.model_dump()) for repo in repos]
+
+    user = user_service.find_by_id(user_id)
+    org_names = org_service.find_org_names_by_ids([r.organization_id for r in repos if r.organization_id is not None])
+
+    return ReposOfUserDTO(user_id=user_id, user_name=user.username, repos=repos, organization_names=org_names)

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -1,10 +1,11 @@
+from typing import List
 from fastapi import APIRouter, Depends
 
 from app.api.repo.repo_dto import RepositoryCreateDTO, RepositoryDTO
 from app.api.repo.repo_service import RepositoryService, get_repo_service
 from app.api.config.auth import get_id_from_jwt, pre_authorize
 from app.api.user.user_model import UserRole
-from app.api.config.auth import JWTBearer, JWTDep
+from app.api.config.auth import JWTBearer, JWTDep, JWTDepOptional
 
 router = APIRouter(prefix="/repositories", tags=["repositories"])
 
@@ -14,3 +15,12 @@ def register_repo(jwt: JWTDep, dto: RepositoryCreateDTO, repo_service: Repositor
     user_id = get_id_from_jwt(jwt)
     repo = repo_service.add(user_id, dto)
     return repo
+
+@router.get("/u/{user_id}", response_model=List[RepositoryDTO], status_code=200, summary="Get repositories of suer")
+def get_repositories_of_user(jwt: JWTDepOptional, user_id: int, repo_service: RepositoryService = Depends(get_repo_service)):
+    me_id = None
+    try: 
+        me_id = get_id_from_jwt(jwt)
+    except: ...
+
+    return repo_service.get_repositories_of_user(user_id, me_id)

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -50,10 +50,11 @@ def get_repositories_of_user(
 def get_repo_by_canonical_name(jwt: JWTDepOptional, repo_canonical_name: str, repo_service: RepositoryService = Depends(get_repo_service)):
     user_id = None
     try: 
-        me_id = get_id_from_jwt(jwt)
+        user_id = get_id_from_jwt(jwt)
     except: ...
 
     repo = repo_service.find_by_canonical_name(repo_canonical_name)
+
     if not repo_service.user_has_read_access_to_repo(repo, user_id):
         raise NotFoundException(Repository, repo_canonical_name)
 

--- a/server/app/api/repo/repo_dto.py
+++ b/server/app/api/repo/repo_dto.py
@@ -1,7 +1,8 @@
-import datetime
+from datetime import datetime
 from typing import Dict, List
 from pydantic import BaseModel, EmailStr, Field
 from app.api.user.user_model import UserRole
+from app.api.repo.repo_model import RepositoryBadge
 
 class RepositoryDTO(BaseModel):
     id: int
@@ -9,9 +10,9 @@ class RepositoryDTO(BaseModel):
     canonical_name: str
     desc: str
     public: bool
-    official: bool
     owner_id: int
     organization_id: int | None = None
+    badge: RepositoryBadge
 
 class RepositoryCreateDTO(BaseModel):
     name: str

--- a/server/app/api/repo/repo_dto.py
+++ b/server/app/api/repo/repo_dto.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Dict, List
 from pydantic import BaseModel, EmailStr, Field
 from app.api.user.user_model import UserRole
 
@@ -12,9 +13,14 @@ class RepositoryDTO(BaseModel):
     owner_id: int
     organization_id: int | None = None
 
-
 class RepositoryCreateDTO(BaseModel):
     name: str
     desc: str
     public: bool
     organization_id: int | None = None
+
+class ReposOfUserDTO(BaseModel):
+    user_id: int
+    user_name: str
+    repos: List[RepositoryDTO]
+    organization_names: Dict[int, str]

--- a/server/app/api/repo/repo_dto.py
+++ b/server/app/api/repo/repo_dto.py
@@ -24,3 +24,7 @@ class ReposOfUserDTO(BaseModel):
     user_name: str
     repos: List[RepositoryDTO]
     organization_names: Dict[int, str]
+
+class RepositoryExtDTO(RepositoryDTO):
+    owner_name: str
+    org_name: str | None

--- a/server/app/api/repo/repo_dto.py
+++ b/server/app/api/repo/repo_dto.py
@@ -13,6 +13,9 @@ class RepositoryDTO(BaseModel):
     owner_id: int
     organization_id: int | None = None
     badge: RepositoryBadge
+    last_updated: datetime
+    downloads: int
+
 
 class RepositoryCreateDTO(BaseModel):
     name: str

--- a/server/app/api/repo/repo_model.py
+++ b/server/app/api/repo/repo_model.py
@@ -48,6 +48,8 @@ class Repository(SQLModel, table=True):
     organization: Organization = Relationship(back_populates="repositories")
 
     badge: RepositoryBadge = Field(default=RepositoryBadge.none)
+    last_updated: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    downloads: int = Field(default=0)
 
     @staticmethod
     def compute_canonical_name(name: str, user: str, official: bool, org: str | None) -> str:

--- a/server/app/api/repo/repo_model.py
+++ b/server/app/api/repo/repo_model.py
@@ -1,9 +1,18 @@
+from datetime import datetime, timezone
+import enum
 from sqlmodel import Field, Relationship, SQLModel
 
 from app.api.org.org_model import Organization
 from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from app.api.user.user_model import User
+
+class RepositoryBadge(str, enum.Enum):
+    none = "none"
+    official = "official"
+    verified = "verified"
+    sponsored_oss = "sponsored_oss"
+
 
 class Repository(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
@@ -24,7 +33,10 @@ class Repository(SQLModel, table=True):
     """
     desc: str = Field(default="")
     public: bool = Field(default=True)
-    official: bool = Field(default=False)
+
+    @property
+    def official(self) -> bool:
+        return self.badge == RepositoryBadge.official
     """
     Official repositories are created and maintained by administrators.
     """
@@ -34,6 +46,8 @@ class Repository(SQLModel, table=True):
 
     organization_id: Optional[int] = Field(default=None, foreign_key="organization.id")
     organization: Organization = Relationship(back_populates="repositories")
+
+    badge: RepositoryBadge = Field(default=RepositoryBadge.none)
 
     @staticmethod
     def compute_canonical_name(name: str, user: str, official: bool, org: str | None) -> str:

--- a/server/app/api/repo/repo_repo.py
+++ b/server/app/api/repo/repo_repo.py
@@ -1,6 +1,8 @@
-from sqlmodel import Session, select
+from typing import List
+from sqlmodel import Session, or_, select
 from app.api.repo.repo_model import Repository
 from app.api.user.user_model import User
+from app.api.org.org_model import Organization, OrganizationMembers
 
 class RepositoryRepo:
     def __init__(self, session: Session):
@@ -17,4 +19,16 @@ class RepositoryRepo:
         
     def find_by_canonical_name(self, canonical_name: str) -> Repository | None:
         return self.session.exec(select(Repository).where(Repository.canonical_name == canonical_name)).first()
-    
+
+    def get_repositories_for_user(self, user_id: int):
+        query = (
+            select(Repository)
+            .join(Organization, Organization.id == Repository.organization_id, isouter=True)
+            .join(OrganizationMembers, OrganizationMembers.organization_id == Organization.id, isouter=True)
+            .where(
+                (OrganizationMembers.user_id == user_id) 
+                | (Repository.organization_id.is_(None) & (Repository.owner_id == user_id))  
+            )
+        )
+
+        return self.session.exec(query).all()

--- a/server/app/api/user/user_service.py
+++ b/server/app/api/user/user_service.py
@@ -56,6 +56,13 @@ class UserService:
             raise UserException("Username or password incorrect")
 
         return sign_jwt(user)
+    
+    def find_by_id(self, id: int) -> User:
+        user = self.user_repo.find_by_id(id)
+        if user is None:
+            raise NotFoundException(User, id)
+        return user
+      
 
 def get_user_service(session: Session = Depends(get_database)) -> UserService:
     return UserService(session)

--- a/server/app/api/user/user_service.py
+++ b/server/app/api/user/user_service.py
@@ -62,6 +62,12 @@ class UserService:
         if user is None:
             raise NotFoundException(User, id)
         return user
+    
+    def find_by_username(self, username: str) -> User:
+        user = self.user_repo.find_by_username(username)
+        if user is None:
+            raise NotFoundException(User, username)
+        return user      
       
 
 def get_user_service(session: Session = Depends(get_database)) -> UserService:

--- a/server/app/tests/test_organization.py
+++ b/server/app/tests/test_organization.py
@@ -87,3 +87,49 @@ def test_add_org_integration():
 
         org1 = response.json()
         assert response.is_error
+
+
+def test_find_org_names_by_ids_valid(org_service):
+    """Test case for when valid org ids are passed."""
+    ids = [1, 2]
+    expected_output = {1: "abc", 2: "def"}
+    org_service.org_repo.find_orgs_by_ids.return_value = expected_output
+
+    result = org_service.find_org_names_by_ids(ids)
+
+    assert result == expected_output
+    org_service.org_repo.find_orgs_by_ids.assert_called_once_with(ids)
+
+
+def test_find_org_names_by_ids_empty_list(org_service):
+    """Test case for when an empty list is passed."""
+    ids = []
+    org_service.org_repo.find_orgs_by_ids.return_value = {}
+
+    result = org_service.find_org_names_by_ids(ids)
+    assert result == {}
+    org_service.org_repo.find_orgs_by_ids.assert_called_once_with(ids)
+
+
+def test_find_org_names_by_ids_partial_match(org_service):
+    """Test case for when some org ids are valid and others are not."""
+    ids = [1, 2, 999999]
+    expected_output = {1: "abc", 2: "def"}
+    org_service.org_repo.find_orgs_by_ids.return_value = expected_output
+
+    result = org_service.find_org_names_by_ids(ids)
+
+    assert result == expected_output
+    org_service.org_repo.find_orgs_by_ids.assert_called_once_with(ids)
+
+
+def test_find_org_names_by_ids_no_matches(org_service):
+    """Test case for when no org ids match."""
+    ids = [999998, 999999]
+    expected_output = {}
+    org_service.org_repo.find_orgs_by_ids.return_value = expected_output
+
+    result = org_service.find_org_names_by_ids(ids)
+
+    assert result == expected_output
+    org_service.org_repo.find_orgs_by_ids.assert_called_once_with(ids)

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -12,7 +12,7 @@ from app.api.config.exception_handler import FieldTakenException, NotFoundExcept
 from app.api.repo.repo_repo import RepositoryRepo
 from app.api.repo.repo_service import RepositoryService
 from app.api.repo.repo_dto import RepositoryCreateDTO
-from app.api.repo.repo_model import Repository
+from app.api.repo.repo_model import Repository, RepositoryBadge
 from app.api.main import app
 from app.api.org.org_repo import OrganizationRepo
 
@@ -185,7 +185,7 @@ def test_add___integration():
         created_repo = response.json()
 
         assert created_repo['canonical_name'] == f'u1/python'
-        assert created_repo['official'] == False
+        assert created_repo['badge'] == RepositoryBadge.none
 
         response = client.post("/api/v1/repositories/", json=data)
         assert response.is_client_error

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -5,7 +5,6 @@ import unittest.mock as mock
 from sqlmodel import Session
 
 from app.api.config.security import hash_password
-from app.api.user.user_dto import UserPasswordChangeDTO, UserRegisterDTO
 from app.api.user.user_model import User, UserRole
 from app.api.user.user_repo import UserRepo
 from app.api.user.user_service import UserService
@@ -15,6 +14,7 @@ from app.api.repo.repo_service import RepositoryService
 from app.api.repo.repo_dto import RepositoryCreateDTO
 from app.api.repo.repo_model import Repository
 from app.api.main import app
+from app.api.org.org_repo import OrganizationRepo
 
 @pytest.fixture
 def mock_session():
@@ -29,6 +29,10 @@ def mock_repo_repo():
     return mock.MagicMock(spec=RepositoryRepo)
 
 @pytest.fixture
+def mock_org_repo():
+    return mock.MagicMock(spec=OrganizationRepo)
+
+@pytest.fixture
 def user_service(mock_session, mock_user_repo):
     service = UserService(mock_session)
     service.user_repo = mock_user_repo
@@ -39,11 +43,15 @@ def repo_service(mock_session):
     service = RepositoryService(mock_session)
     service.repo_repo = mock.MagicMock(spec=RepositoryRepo)
     service.user_repo = mock.MagicMock(spec=UserRepo)
+    service.org_repo = mock.MagicMock(spec=OrganizationRepo)
     return service
+
+@pytest.fixture
+def mock_repo():
+    return mock.MagicMock(Repository)
 
 def create_mock_user(id: int, username: str, role: UserRole):
     return User(id=id, email=f"username@email.com", username=username, role=role, hashed_password=hash_password("1234"))
-
 
 
 def test_add_repo(repo_service):
@@ -63,6 +71,7 @@ def test_add_repo(repo_service):
 
     assert repo_result.id is not None
 
+
 def test_add_repo__no_user(repo_service):
     repo_service.user_repo.find_by_id.return_value = None
     dto = RepositoryCreateDTO(
@@ -77,6 +86,7 @@ def test_add_repo__no_user(repo_service):
     
     assert e.value.entity_type == User
     assert e.value.identifier == 1
+
 
 def test_add_repo__repo_name(repo_service):
     user1 = create_mock_user(1, "user1", UserRole.user)
@@ -134,6 +144,7 @@ def test_add_repo__repo_name(repo_service):
     with pytest.raises(FieldTakenException) as e:
         repo_service.add(3, dto)
 
+
 def test_add___integration():
     with TestClient(app) as client:
         data = {
@@ -170,3 +181,146 @@ def test_add___integration():
 
         response = client.post("/api/v1/repositories/", json=data)
         assert response.is_client_error
+
+        
+def test_find_by_canonical_name_success(repo_service):
+    """Test case for when the repository is found."""
+    canonical_name = "user1/python"
+    expected_repo = mock.MagicMock(Repository)
+    
+    repo_service.repo_repo.find_by_canonical_name.return_value = expected_repo
+    
+    result = repo_service.find_by_canonical_name(canonical_name)
+    
+    assert result == expected_repo
+    repo_service.repo_repo.find_by_canonical_name.assert_called_once_with(canonical_name)
+
+
+def test_find_by_canonical_name_not_found(repo_service):
+    """Test case for when the repository is not found."""
+    canonical_name = "user7438437/python"
+    
+    repo_service.repo_repo.find_by_canonical_name.return_value = None
+    
+    with pytest.raises(NotFoundException):
+        repo_service.find_by_canonical_name(canonical_name)
+    
+    repo_service.repo_repo.find_by_canonical_name.assert_called_once_with(canonical_name)
+
+
+def test_user_has_read_access_to_repo_public(repo_service, mock_repo):
+    """Test case for when the repository is public."""
+    mock_repo.public = True
+    
+    assert repo_service.user_has_read_access_to_repo(mock_repo, None) == True
+    assert repo_service.user_has_read_access_to_repo(mock_repo, 1) == True
+
+
+def test_user_has_read_access_to_repo_private_signed_out(repo_service, mock_repo):
+    mock_repo.public = False
+    mock_repo.owner_id = 1
+    mock_repo.organization_id = None
+    
+    assert repo_service.user_has_read_access_to_repo(mock_repo, None) == False
+
+
+def test_user_has_read_access_to_repo_private_personal_owner(repo_service, mock_repo):
+    """Test case for when the repository is personal, and the user is the owner."""
+    mock_repo.public = False
+    mock_repo.owner_id = 1
+    mock_repo.organization_id = None
+    
+    # I am the owner of this private repo.
+    assert repo_service.user_has_read_access_to_repo(mock_repo, 1) == True
+    # Someone else is the owner of this private personal repo.
+    assert repo_service.user_has_read_access_to_repo(mock_repo, 2) == False
+
+
+def test_user_has_read_access_to_repo_private_org_member(repo_service, mock_repo):
+    """Test case for when the repository is an organization repository and the user is a member."""
+    mock_repo.public = False
+    mock_repo.owner_id = 1
+    mock_repo.organization_id = 1
+    
+    # Member of the org.
+    repo_service.org_repo.user_is_in_org.return_value = True
+    assert repo_service.user_has_read_access_to_repo(mock_repo, 1) == True
+    
+    # Outsider relative to the org.
+    repo_service.org_repo.user_is_in_org.return_value = False
+    assert repo_service.user_has_read_access_to_repo(mock_repo, 1) == False
+
+
+def test_user_has_read_access_to_repo_private_org_not_member(repo_service, mock_repo):
+    """Test case for when the repository is an organization repository and the user is not a member."""
+    mock_repo.public = False
+    mock_repo.owner_id = 1
+    mock_repo.organization_id = 1
+    
+    # Outsider relative to org.
+    repo_service.org_repo.user_is_in_org.return_value = False
+    assert repo_service.user_has_read_access_to_repo(mock_repo, 1) == False
+
+"""
+NOTE: `user_had_red_access` has way too many possible cases to test them all because
+of the number of variables:
+
+- am i logged in
+    - am i the owner of this repo
+- is the repo public
+- is the repo in an organization
+    - am i a member of this repo
+
+So instead, `user_had_red_access` is done with whitebox testing.
+The integration tests should cover some interesting cases (if any).
+"""
+
+def test_get_repositories_of_user_all_accessible(repo_service, mock_repo):
+    """Test case for when all repositories are accessible by whos_asking_user_id."""
+    user_id = 1
+    whos_asking_user_id = 2
+
+    repo_service.repo_repo.get_repositories_for_user.return_value = [mock_repo, mock_repo]
+    repo_service.user_has_read_access_to_repo = mock.MagicMock(return_value=True)
+
+    result = repo_service.get_repositories_of_user(user_id, whos_asking_user_id)
+
+    assert len(result) == 2
+    assert result == [mock_repo, mock_repo]
+    repo_service.repo_repo.get_repositories_for_user.assert_called_once_with(user_id)
+    repo_service.user_has_read_access_to_repo.assert_any_call(mock_repo, whos_asking_user_id)
+
+
+def test_get_repositories_of_user_some_accessible(repo_service):
+    """Test case for when some repositories are not accessible by whos_asking_user_id."""
+    user_id = 1
+    whos_asking_user_id = 2
+
+    repo1 = mock.MagicMock(Repository)
+    repo1.id = 1
+    
+    repo2 = mock.MagicMock(Repository)
+    repo2.id = 2
+
+    repo_service.repo_repo.get_repositories_for_user.return_value = [repo1, repo2]
+    repo_service.user_has_read_access_to_repo = mock.MagicMock(side_effect=[True, False])
+
+    result = repo_service.get_repositories_of_user(user_id, whos_asking_user_id)
+
+    assert len(result) == 1
+    assert result == [repo1]
+    repo_service.repo_repo.get_repositories_for_user.assert_called_once_with(user_id)
+    repo_service.user_has_read_access_to_repo.assert_any_call(repo1, whos_asking_user_id)
+
+
+def test_get_repositories_of_user_no_repositories(repo_service):
+    """Test case for when there are no repositories returned for the user."""
+    user_id = 1
+    whos_asking_user_id = 2
+
+    repo_service.repo_repo.get_repositories_for_user.return_value = []
+
+    result = repo_service.get_repositories_of_user(user_id, whos_asking_user_id)
+
+    assert result == []
+    repo_service.repo_repo.get_repositories_for_user.assert_called_once_with(user_id)

--- a/server/app/tests/test_user.py
+++ b/server/app/tests/test_user.py
@@ -19,6 +19,10 @@ def mock_user_repo():
     return mock.MagicMock(spec=UserRepo)
 
 @pytest.fixture
+def mock_user():
+    return mock.MagicMock(User)
+
+@pytest.fixture
 def user_service(mock_session, mock_user_repo):
     service = UserService(mock_session)
     service.user_repo = mock_user_repo
@@ -59,3 +63,43 @@ def test_change_password_new_password_is_same_as_current_password(user_service, 
 
     with pytest.raises(UserException) as e:
         user_service.change_password(1, dto)
+
+def test_find_by_id_user_found(user_service, mock_user):
+    """Test case for when a user is found by ID."""
+    user_id = 1
+    user_service.user_repo.find_by_id.return_value = mock_user
+
+    result = user_service.find_by_id(user_id)
+
+    assert result == mock_user
+    user_service.user_repo.find_by_id.assert_called_once_with(user_id)
+
+def test_find_by_id_user_not_found(user_service):
+    """Test case for when a user is not found by ID."""
+    user_id = 1
+    user_service.user_repo.find_by_id.return_value = None
+
+    with pytest.raises(NotFoundException):
+        user_service.find_by_id(user_id)
+
+    user_service.user_repo.find_by_id.assert_called_once_with(user_id)
+
+def test_find_by_username_user_found(user_service, mock_user):
+    """Test case for when a user is found by username."""
+    username = "bob"
+    user_service.user_repo.find_by_username.return_value = mock_user
+
+    result = user_service.find_by_username(username)
+
+    assert result == mock_user
+    user_service.user_repo.find_by_username.assert_called_once_with(username)
+
+def test_find_by_username_user_not_found(user_service):
+    """Test case for when a user is not found by username."""
+    username = "bob"
+    user_service.user_repo.find_by_username.return_value = None
+
+    with pytest.raises(NotFoundException):
+        user_service.find_by_username(username)
+
+    user_service.user_repo.find_by_username.assert_called_once_with(username)


### PR DESCRIPTION
Closes #15 

Currently, the user home page is `/u/{username}/repos`. This takes you to the list of repositories of the user `{username}`. The page also features client-side searching and filtering.

Which repository will be shown depends on its visibility, whether it belongs to an organization, and the user making the request (or guest, if you're signed out). Check `repo_service::user_has_read_access_to_repo()` for implementation details.

Clicking on the name of any repository opens the main page of that repository, under the URL `/r/{repo_canonical_name}`. Page design is based on DockerHub's repository page design: there's a tabbed pane with "overview" and "tags". For now, both are placeholders as those can be a separate feature.

---

**NOTE**: I would appreciate if the code review actually had the code being... reviewed. Focus on the backend: the frontend is barebones. If you care about the web app, provide feedback on what I should change on the UI/UX side. This isn't a complicated feature but we're establishing conventions and app architecture as we go, so code review is a good place to figure out how things work. I try my best to keep the commits isolated both between layers (frontend vs backend) and between features (user vs repo vs org). All in the name of readability.