### PR TITLE
Feature admin register

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { NotFound } from './pages/NotFound';
 import { RepoCreate } from './pages/RepoCreate';
 import { UserPasswordChangeRequired } from './pages/UserPasswordChangeRequired';
 import { UserRegistration } from './pages/UserRegistration';
+import { UserAdminRegistration } from './pages/UserAdminRegistration';
 import { UserLogin } from './pages/UserLogin';
 import { BrowserRouter, Route, RouteProps, Routes } from "react-router";
 import { UserLogout } from './pages/UserLogout';
@@ -39,6 +40,7 @@ function App() {
                 <Navbar />
                 <Routes>
                     {authRoute("/register", [""], UserRegistration)}
+                    {authRoute("/register-admin", ["superadmin"], UserAdminRegistration)}
 
                     {/* Anybody. */}
                     {authRoute("/", [], Home)}

--- a/client/src/api/user.api.ts
+++ b/client/src/api/user.api.ts
@@ -48,4 +48,8 @@ export class UserService {
     static async LoginUser(dto: UserLoginDTO): Promise<AxiosResponse<TokenDTO>> {
         return await axiosInstance.post(`/users/login`, dto);
     }
+
+    static async RegisterAdmin(dto: UserRegisterDTO): Promise<void> {
+        return await axiosInstance.post(`/users/register-admin`, dto);
+    }
 }

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -31,6 +31,7 @@ export function Navbar() {
             {
                 role === 'superadmin' &&
                 <>
+                    <NavLink className={"navlink"} to="/register-admin" end>New admin</NavLink>
                 </>
             }
             {

--- a/client/src/pages/UserAdminRegistration.tsx
+++ b/client/src/pages/UserAdminRegistration.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { Form, Button, Container, Row, Col, Alert } from 'react-bootstrap';
+import './UserRegistration.css';
+import { UserRegisterDTO, UserService } from '../api/user.api';
+import { AxiosError } from 'axios';
+
+const initialFormState = {
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: ''
+}
+
+export const UserAdminRegistration = () => {
+    const [formData, setFormData] = useState(initialFormState);
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState('');
+
+    const handleChange = (e: any) => {
+        const { name, value } = e.target;
+        setFormData({
+            ...formData,
+            [name]: value
+        });
+    };
+
+    const handleSubmit = (e: any) => {
+        e.preventDefault();
+        if (!formData.username || !formData.email || !formData.password || !formData.confirmPassword) {
+            setError('All fields are required');
+            setSuccess('');
+            return;
+        }
+        if (formData.password !== formData.confirmPassword) {
+            setError('Passwords do not match');
+            setSuccess('');
+            return;
+        }
+        setError('');
+        setSuccess('');
+
+        let dto: UserRegisterDTO = {
+            email: formData.email,
+            username: formData.username,
+            password: formData.password,
+        };
+        UserService.RegisterAdmin(dto).then(() => {
+            setFormData(initialFormState);
+            setSuccess("Admin " + dto.username + " is successfully registered!")
+        }).catch((err: AxiosError) => {
+            setError((err.response?.data as any)["detail"]["message"]);
+        });
+    };
+
+    return (
+        <Container className="registration-container">
+            <Row className="justify-content-md-center">
+                <Col md={6}>
+                    <h2 className="mt-5">Register admin</h2>
+                    {error && <Alert variant="danger">{error}</Alert>}
+                    {success && <Alert variant="success">{success}</Alert>}
+                    <Form onSubmit={handleSubmit}>
+                        <Form.Group as={Row} controlId="formUsername">
+                            <Form.Label column sm={3}>Username</Form.Label>
+                            <Col sm={9}>
+                                <Form.Control
+                                    type="text"
+                                    name="username"
+                                    placeholder="Enter admin username"
+                                    value={formData.username}
+                                    onChange={handleChange}
+                                    required
+                                />
+                            </Col>
+                        </Form.Group>
+
+                        <Form.Group as={Row} controlId="formEmail">
+                            <Form.Label column sm={3}>Email</Form.Label>
+                            <Col sm={9}>
+                                <Form.Control
+                                    type="email"
+                                    name="email"
+                                    placeholder="user@example.org"
+                                    value={formData.email}
+                                    onChange={handleChange}
+                                    required
+                                />
+                            </Col>
+                        </Form.Group>
+
+                        <Form.Group as={Row} controlId="formPassword">
+                            <Form.Label column sm={3}>Password</Form.Label>
+                            <Col sm={9}>
+                                <Form.Control
+                                    type="password"
+                                    name="password"
+                                    placeholder="Enter admin password"
+                                    value={formData.password}
+                                    onChange={handleChange}
+                                    required
+                                />
+                            </Col>
+                        </Form.Group>
+
+                        <Form.Group as={Row} controlId="formConfirmPassword">
+                            <Form.Label column sm={3}>Confirm Password</Form.Label>
+                            <Col sm={9}>
+                                <Form.Control
+                                    type="password"
+                                    name="confirmPassword"
+                                    placeholder="Confirm admin password"
+                                    value={formData.confirmPassword}
+                                    onChange={handleChange}
+                                    required
+                                />
+                            </Col>
+                        </Form.Group>
+
+                        <div className="d-flex justify-content-center">
+                            <Button variant="primary" type="submit" className="mt-3">
+                                Register
+                            </Button>
+                        </div>
+                    </Form>
+                </Col>
+            </Row>
+        </Container>
+    );
+};

--- a/server/app/api/user/user_controller.py
+++ b/server/app/api/user/user_controller.py
@@ -25,6 +25,11 @@ def change_user_password(jwt: JWTDep, dto: UserPasswordChangeDTO, user_service: 
     user_id = get_id_from_jwt(jwt)
     user_service.change_password(user_id, dto)
 
+@router.post("/register-admin", response_model=UserDTO, summary="Register a new admin")
+@pre_authorize([UserRole.superadmin])
+def register_admin(jwt: JWTDep, dto: UserRegisterDTO, user_service: UserService = Depends(get_user_service)):
+    return user_service.add_admin(dto)
+
 @router.get("/test")
 @cache(expire=10)
 @pre_authorize(["superadmin"])

--- a/server/app/api/user/user_controller.py
+++ b/server/app/api/user/user_controller.py
@@ -20,7 +20,7 @@ def login_user(dto: UserLoginDTO, user_service: UserService = Depends(get_user_s
     return UserTokenDTO(token=token)
 
 @router.post("/password", status_code=204, summary="Change the user's password")
-@pre_authorize(["user", "admin", UserRole.superadmin], ignore_password_change_requirement=True)
+@pre_authorize([UserRole.user, UserRole.admin, UserRole.superadmin], ignore_password_change_requirement=True)
 def change_user_password(jwt: JWTDep, dto: UserPasswordChangeDTO, user_service: UserService = Depends(get_user_service)):
     user_id = get_id_from_jwt(jwt)
     user_service.change_password(user_id, dto)
@@ -32,7 +32,7 @@ def register_admin(jwt: JWTDep, dto: UserRegisterDTO, user_service: UserService 
 
 @router.get("/test")
 @cache(expire=10)
-@pre_authorize(["superadmin"])
+@pre_authorize([UserRole.superadmin])
 def test(jwt: JWTDep):
     return [
         { "id": 0, "name": "Aza" },

--- a/server/app/api/user/user_service.py
+++ b/server/app/api/user/user_service.py
@@ -57,5 +57,10 @@ class UserService:
 
         return sign_jwt(user)
 
+    def add_admin(self, dto: UserRegisterDTO) -> User:
+        user = self.add(dto)
+        user = self.user_repo.set_role(user, UserRole.admin)
+        return user
+
 def get_user_service(session: Session = Depends(get_database)) -> UserService:
     return UserService(session)

--- a/server/app/tests/test_user.py
+++ b/server/app/tests/test_user.py
@@ -4,11 +4,11 @@ import unittest.mock as mock
 from sqlmodel import Session
 
 from app.api.config.security import hash_password
-from app.api.user.user_dto import UserPasswordChangeDTO
+from app.api.user.user_dto import UserPasswordChangeDTO, UserRegisterDTO
 from app.api.user.user_model import User, UserRole
 from app.api.user.user_repo import UserRepo
 from app.api.user.user_service import UserService
-from app.api.config.exception_handler import NotFoundException, UserException
+from app.api.config.exception_handler import NotFoundException, UserException, FieldTakenException
 
 @pytest.fixture
 def mock_session():
@@ -59,3 +59,43 @@ def test_change_password_new_password_is_same_as_current_password(user_service, 
 
     with pytest.raises(UserException) as e:
         user_service.change_password(1, dto)
+
+def test_add_admin(user_service, mock_user_repo):
+    dto = UserRegisterDTO(username="Username1", email="a@email.com", password="Password1")
+    new_user = User(id=1, username="Username1", email="a@email.com", role=UserRole.user, hashed_password=hash_password("Password1"))
+
+    mock_user_repo.find_by_email.return_value = None
+    mock_user_repo.find_by_username.return_value = None
+    mock_user_repo.add.return_value = new_user
+    mock_user_repo.set_role.return_value = User(
+        id=1, username="Username1", email="a@email.com", role=UserRole.admin, hashed_password=hash_password("Password1")
+    )
+
+    test_result = user_service.add_admin(dto)
+
+    assert test_result.id == 1
+
+def test_add_admin_new_admin_username_already_exists(user_service, mock_user_repo):
+    dto = UserRegisterDTO(username="Username1", email="a@email.com", password="Password1")
+    start_user =  User(id=1, username="Username1", email="b@email.com", role=UserRole.admin, hashed_password=hash_password("Password1"))
+
+    mock_user_repo.find_by_email.return_value = None  
+    mock_user_repo.find_by_username.return_value = start_user
+
+    with pytest.raises(FieldTakenException) as e:
+        user_service.add_admin(dto)
+
+    assert e.value.message == "Username already taken"
+
+def test_add_admin_new_admin_email_already_exists(user_service, mock_user_repo):
+    dto = UserRegisterDTO(username="Username1", email="a@email.com", password="Password1")
+    start_user =  User(id=1, username="Username2", email="a@email.com", role=UserRole.admin, hashed_password=hash_password("Password1"))
+
+    mock_user_repo.find_by_email.return_value = start_user  
+    mock_user_repo.find_by_username.return_value = None
+
+    with pytest.raises(FieldTakenException) as e:
+        user_service.add_admin(dto)
+
+    assert e.value.message == "Email already taken"
+


### PR DESCRIPTION
Closes #3.

After logging in, a super admin can add a new regular admin using a straightforward registration form.

Since adding a new admin relies on the process of registering a new user, unit and integration tests have been implemented for both functionalities.


