### PR TITLE
`create organization` web app improvements

### DIFF
--- a/client/src/api/org.api.ts
+++ b/client/src/api/org.api.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from "axios";
-import { axiosInstance } from "../util/http";
+import { axiosInstance, ENV } from "../util/http";
 
 export interface OrganizationCreateDTO {
     name: string
@@ -38,5 +38,9 @@ export class OrganizationService {
 
     static async GetMyOrganizations(): Promise<AxiosResponse<OrganizationDTOBasic[]>> {
         return await axiosInstance.get(`/organizations/my`);
+    }
+
+    static GetImageURI = (filename: string): string => {
+        return `${ENV.IMG}${filename}`;
     }
 }

--- a/client/src/pages/OrgCreate.tsx
+++ b/client/src/pages/OrgCreate.tsx
@@ -1,9 +1,11 @@
 import React, { useRef, useState } from 'react';
-import { Form, Button, Alert, Row, Col } from 'react-bootstrap';
+import { Form, Button, Alert, Row, Col, Spinner } from 'react-bootstrap';
 import './OrgCreate.css';
 import { fileToBase64 } from '../util/image';
 import { OrganizationCreateDTO, OrganizationService } from '../api/org.api';
 import { AxiosError } from 'axios';
+import { ToastType, useToastStore } from '../util/toastStore';
+import { useNavigate } from 'react-router-dom';
 
 export const OrganizationCreate = () => {
     const [name, setName] = useState('');
@@ -12,8 +14,12 @@ export const OrganizationCreate = () => {
     const [imagePreview, setImagePreview] = useState<string | null>(null);
     const [errors, setErrors] = useState<{ name?: string; description?: string; image?: string }>({});
     const [error, setError] = useState('');
+    const [loading, setLoading] = useState(false);
 
     const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const navigate = useNavigate();
+    const addToast = useToastStore((state) => state.addToast);
 
     const validateForm = () => {
         const newErrors: { name?: string; description?: string; image?: string } = {};
@@ -43,10 +49,15 @@ export const OrganizationCreate = () => {
 
             setError('');
             setErrors({});
+            setLoading(true);
             OrganizationService.CreateOrganization(dto).then((res) => {
-                console.log(res);
+                const org = res.data;
+                addToast(`Created organization ${org.name}`, ToastType.success);
+                navigate(`/o/${org.name}`);
             }).catch((err: AxiosError) => {
                 setError((err.response?.data as any)["detail"]["message"]);
+            }).finally(() => {
+                setLoading(false);
             });
         } else {
             setErrors(formErrors);
@@ -134,6 +145,14 @@ export const OrganizationCreate = () => {
 
             <div className="d-flex justify-content-end mt-5">
                 <Button variant="primary" type="submit">
+                    {loading && (
+                        <Spinner
+                            as="span"
+                            size="sm"
+                            role="status"
+                            aria-hidden="true"
+                        > </Spinner>
+                    )}
                     Create Organization
                 </Button>
             </div>

--- a/client/src/pages/RepoCreate.tsx
+++ b/client/src/pages/RepoCreate.tsx
@@ -12,6 +12,7 @@ interface Owner {
     name: string;
     user_id: number | null;
     organization_id: number | null;
+    image_path: string | null;
 }
 
 export const RepoCreate = () => {
@@ -38,14 +39,15 @@ export const RepoCreate = () => {
                 return {
                     name: o.name,
                     user_id: null,
-                    organization_id: o.id
+                    organization_id: o.id,
+                    image_path: o.image,
                 };
             });
 
             // Create list of "owners" (the user himself + all the organizations above).
 
-            const all_possible_owners = [
-                { name: "user 1", user_id: getJwtId(), organization_id: null },
+            const all_possible_owners: Owner[] = [
+                { name: "user 1", user_id: getJwtId(), organization_id: null, image_path: null },
                 ...organizations_i_can_make_repos_in
             ]
             setOwners(all_possible_owners);
@@ -141,6 +143,12 @@ export const RepoCreate = () => {
                         >
                             {owners.map((o) => (
                                 <Dropdown.Item key={o.name} eventKey={o.name}>
+                                    {o.image_path !== null && (
+                                        <img
+                                            src={`${OrganizationService.GetImageURI(o.image_path)}`}
+                                            style={{ width: '50px', height: '50px', objectFit: 'cover', marginRight: '10px' }}
+                                        />
+                                    )}
                                     {userOrOrgToStr(o)}
                                 </Dropdown.Item>
                             ))}

--- a/client/src/util/http.ts
+++ b/client/src/util/http.ts
@@ -1,8 +1,13 @@
 import axios from "axios";
 import { getJWTStringOrNull } from "./localstorage";
 
+export const ENV = {
+    API: 'http://127.0.0.1/api/',
+    IMG: 'http://localhost/img/',
+};
+
 export const axiosInstance = axios.create({
-    baseURL: 'http://127.0.0.1/api/',
+    baseURL: ENV.API,
 });
 
 axiosInstance.interceptors.request.use(

--- a/images/.gitignore
+++ b/images/.gitignore
@@ -1,2 +1,4 @@
 *.png
+*.jpeg
+*.jpg
 !sample.png

--- a/server/app/api/config/images.py
+++ b/server/app/api/config/images.py
@@ -1,13 +1,18 @@
 import base64
 import os
 import random
+from typing import Tuple
 from PIL import Image, ImageDraw, ImageFont
 import hashlib
 import base64
 from io import BytesIO
 
 
-def save_image(inline_image_base64: str, filename_without_path_or_extension: str) -> str:
+def save_image(inline_image_base64: str, filename_without_path_or_extension: str) -> Tuple[str, str]:
+    """
+    Returns: `(file_path, file_name)`
+    e.g. `(C:/.../images/abc.png, abc.png)`
+    """
     header, encoded = inline_image_base64.split(",", 1)
     file_format = header.split("/")[1].split(";")[0]
 
@@ -20,7 +25,7 @@ def save_image(inline_image_base64: str, filename_without_path_or_extension: str
         with open(filepath, "wb") as f:
             f.write(image_bytes)
 
-    return filepath
+    return (filepath, filename)
 
 
 def generate_inline_image(text: str, size: int=128, block_size=16) -> str:

--- a/server/app/api/org/org_model.py
+++ b/server/app/api/org/org_model.py
@@ -22,6 +22,9 @@ class Organization(SQLModel, table=True):
     name: str = Field()
     desc: str = Field(default="")
     image: str = Field(default="")
+    """
+    Path to the image, relative to the internal `/images/` folder.
+    """
 
     owner_id: int = Field(default=None, foreign_key="user.id")
     owner: "User" = Relationship()

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -23,12 +23,13 @@ class OrganizationService:
 
         if dto.image is None:
             dto.image = generate_inline_image(dto.name)
-        save_image(dto.image, f"org-{dto.name}")
+        image_fname = save_image(dto.image, f"org-{dto.name}")[1]
 
         # Create the organization.
 
         new_org = Organization.model_validate(dto, update={
             "owner_id": user_id,
+            "image": image_fname,
         })
 
         org = self.org_repo.add(new_org)


### PR DESCRIPTION
Closes second half of issue #19 (first half was covered by PR #21).
It works exactly the same as when creating a repository (loading spinner, navigate to org page (this isn't implemented yet, so it redirects to 404), toast popup).

Bonus: I fixed the `Organization` model. The column `image` now stores the filename of the organization's image. Example of usage: the `create repo` page shows images when you click on the dropdown menu.