### PR TITLE
Elasticsearch setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,5 +29,8 @@ jobs:
         echo "RUN_TESTS=true" > .env
 
     - name: Run the tests
+      # Specify that we're bulding `backend` => `--abort-on-container-exit` will only work for `backend`
+      # But we must be careful about `depends-on` in `compose.yaml`.
+      # https://stackoverflow.com/a/76049965
       run: |
-        sudo docker compose up --build
+        sudo docker compose up --build backend --abort-on-container-exit --exit-code-from backend

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,8 +24,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r server/requirements.txt
 
-    - name: Run the tests
-      env:
-        mocker_hub_TEST_ENV: 1
+    - name: Create .env file
       run: |
-        pytest server/app/tests/
+        echo "RUN_TESTS=true" > .env
+
+    - name: Run the tests
+      run: |
+        sudo docker compose up --build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.db
 *.log
+*.log.*
 
 .env
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.db
+*.log
 
 .env
 .venv

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 ![Static Badge](https://img.shields.io/badge/license-BSD_2_Clause-blue)
 
+[![Python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=fff)](#)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=fff)](#)
+[![Bash](https://img.shields.io/badge/Bash-4EAA25?logo=gnubash&logoColor=fff)](#)
+[![CSS](https://img.shields.io/badge/CSS-1572B6?logo=css3&logoColor=fff)](#)
+[![Sass](https://img.shields.io/badge/Sass-C69?logo=sass&logoColor=fff)](#)
+[![HTML](https://img.shields.io/badge/HTML-%23E34F26.svg?logo=html5&logoColor=white)](#)
+![YAML](https://img.shields.io/badge/yaml-%23ffffff.svg?logo=yaml&logoColor=151515)
+[![JSON](https://img.shields.io/badge/JSON-000?logo=json&logoColor=fff)](#)
+![JWT](https://img.shields.io/badge/JWT-black?logo=JSON%20web%20tokens)
+
 [![FastAPI](https://img.shields.io/badge/FastAPI-009485.svg?logo=fastapi&logoColor=white)](#)
 [![Postgres](https://img.shields.io/badge/Postgres-%23316192.svg?logo=postgresql&logoColor=white)](#)
 ![Nginx](https://img.shields.io/badge/nginx-%23009639?logo=nginx)
@@ -10,6 +20,9 @@
 [![React](https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB)](#)
 [![Bootstrap](https://img.shields.io/badge/Bootstrap-7952B3?logo=bootstrap&logoColor=fff)](#)
 [![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=fff)](#)
+![Docker](https://img.shields.io/badge/Docker_Compose-%230db7ed.svg?logo=docker&logoColor=white)
+![ElasticSearch](https://img.shields.io/badge/-ElasticSearch-005571?logo=elasticsearch)
+![Pytest](https://img.shields.io/badge/pytest-%23ffffff.svg?logo=pytest&logoColor=2f9fe3)
 [![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?logo=github-actions&logoColor=white)](#)
 
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/magley/mocker-hub?cacheSeconds=3600) ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-pr/magley/mocker-hub?cacheSeconds=3600)

--- a/compose.yaml
+++ b/compose.yaml
@@ -86,25 +86,24 @@ services:
       - "./distribution/certs:/mnt/local/certs"
 
   elasticsearch:
-      image: docker.elastic.co/elasticsearch/elasticsearch:8.6.2
-      container_name: elasticsearch
-      environment:
-        - discovery.type=single-node
-        - ES_JAVA_OPTS=-Xms256m -Xmx256m  # In case we run out of memory, change 256m to 512m or 1g
-        - ELASTIC_PASSWORD=1234
-        - xpack.security.enabled=false
-        - xpack.ml.enabled=false
-      ports:
-        - 9200:9200
-        - 9300:9300
-      # I've added these lines below to speed up the booting of ES. In case something goes wrong, comment them out.
-      volumes:
-      - /tmp/elasticsearch/data
-      ulimits:
-        memlock:
-          soft: -1
-          hard: -1
-
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.6.2
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms256m -Xmx256m  # In case we run out of memory, change 256m to 512m or 1g
+      - ELASTIC_PASSWORD=1234
+      - xpack.security.enabled=false
+      - xpack.ml.enabled=false
+    ports:
+      - 9200:9200
+      - 9300:9300
+    # I've added these lines below to speed up the booting of ES. In case something goes wrong, comment them out.
+    volumes:
+    - /tmp/elasticsearch/data
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
 
   log_collector:
     build: ./log_collector

--- a/compose.yaml
+++ b/compose.yaml
@@ -99,6 +99,7 @@ services:
 
   log_collector:
     build: ./log_collector
+    restart: on-failure
     volumes:
       - ./logs:/logs
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,6 +23,8 @@ services:
       SUPERADMIN_PASSWORD: admin123
       JWT_SECRET: secret
       JWT_ALGORITHM: HS256
+      ELASTICSEARCH_HOST: elasticsearch
+      ELASTICSEARCH_PORT: 9200
 
       # To run tests, do `RUN_TESTS=true docker compose up`.
       # However, I've been having issues with this on WSL,

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,10 @@ services:
     depends_on:
       - db
       - cache
+      - nginx
       - elasticsearch
+      - distribution
+      - log_collector
     environment:
       PYTHONUNBUFFERED: 1
       POSTGRES_USER: postgres
@@ -69,11 +72,8 @@ services:
     build: ./nginx/
     ports:
       - "80:80"
-    depends_on:
-      - backend
     volumes:
       - ./images:/usr/share/nginx/html/images
-
 
   cache:
     image: redis:alpine3.20

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,7 +20,13 @@ services:
       SUPERADMIN_PASSWORD: admin123
       JWT_SECRET: secret
       JWT_ALGORITHM: HS256
-    restart: always
+
+      # To run tests, do `RUN_TESTS=true docker compose up`.
+      # However, I've been having issues with this on WSL,
+      # so instead I've created an `.env` in project root
+      # with RUN_TESTS=true.
+      RUN_TESTS: ${RUN_TESTS:-false}
+    restart: on-failure
     
     develop:
       watch:

--- a/compose.yaml
+++ b/compose.yaml
@@ -97,6 +97,14 @@ services:
         - 9200:9200
         - 9300:9300
 
+  log_collector:
+    build: ./log_collector
+    volumes:
+      - ./logs:/logs
+    environment:
+      - ES_HOST=elasticsearch:9200
+    depends_on:
+      - elasticsearch
 
 volumes:
   backend_cfg:

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,7 @@ services:
       - backend_cfg:/code/volume-server-cfg/
       - ./images:/code/images
       - "./distribution/certs:/mnt/local/certs"
+      - ./logs:/code/logs
 
   db:
     image: postgres:15.9-alpine3.20

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,7 @@ services:
     depends_on:
       - db
       - cache
+      - elasticsearch
     environment:
       PYTHONUNBUFFERED: 1
       POSTGRES_USER: postgres
@@ -82,6 +83,18 @@ services:
     volumes:
       - "./distribution/config.yaml:/etc/docker/registry/config.yml"
       - "./distribution/certs:/mnt/local/certs"
+
+  elasticsearch:
+      image: docker.elastic.co/elasticsearch/elasticsearch:8.6.2
+      container_name: elasticsearch
+      environment:
+        - discovery.type=single-node
+        - ES_JAVA_OPTS=-Xmx1g -Xms1g
+        - ELASTIC_PASSWORD=1234
+        - xpack.security.enabled=false
+      ports:
+        - 9200:9200
+        - 9300:9300
 
 
 volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -90,12 +90,21 @@ services:
       container_name: elasticsearch
       environment:
         - discovery.type=single-node
-        - ES_JAVA_OPTS=-Xmx1g -Xms1g
+        - ES_JAVA_OPTS=-Xms256m -Xmx256m  # In case we run out of memory, change 256m to 512m or 1g
         - ELASTIC_PASSWORD=1234
         - xpack.security.enabled=false
+        - xpack.ml.enabled=false
       ports:
         - 9200:9200
         - 9300:9300
+      # I've added these lines below to speed up the booting of ES. In case something goes wrong, comment them out.
+      volumes:
+      - /tmp/elasticsearch/data
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+
 
   log_collector:
     build: ./log_collector

--- a/log_collector/Dockerfile
+++ b/log_collector/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["python", "log_collector.py"]

--- a/log_collector/event.py
+++ b/log_collector/event.py
@@ -1,0 +1,16 @@
+from enum import Enum
+from elasticsearch_dsl import Document, Text, Date, Keyword
+
+class EventLevel(Enum):
+    Debug = "debug"
+    Info = "info"
+    Warning = "warning"
+    Error = "error"
+
+class Event(Document):
+    date_time = Date()
+    log_level = Keyword()
+    text_content = Text()
+
+    class Index:
+        name = 'events'

--- a/log_collector/log_collector.py
+++ b/log_collector/log_collector.py
@@ -23,7 +23,8 @@ polling_interval = 5
 
 logging.info("Connecting to ElasticSearch...")
 try:
-    connections.create_connection(hosts=["http://elasticsearch:9200"])
+    hostname = os.getenv("ES_HOST", "elasticsearch:9200")
+    connections.create_connection(hosts=[f"http://{hostname}"])
     Event.init()
     logging.info("Connected to ElasticSearch!")
 except Exception as e:

--- a/log_collector/log_collector.py
+++ b/log_collector/log_collector.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+import time
+import os
+import logging
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers.polling import PollingObserver
+from elasticsearch_dsl import connections
+from event import Event, EventLevel
+
+# Configure logging.
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),
+    ]
+)
+
+polling_interval = 5
+
+# Connect to ElasticSearch.
+
+logging.info("Connecting to ElasticSearch...")
+try:
+    connections.create_connection(hosts=["http://elasticsearch:9200"])
+    Event.init()
+    logging.info("Connected to ElasticSearch!")
+except Exception as e:
+    logging.error(f"Failed to connect to ElasticSearch: {e}")
+    exit(1)
+
+def send_log_to_es(log_line: str):
+    """
+    Send a single log entry (a single line) to ElasticSearch.
+    The line should have the following format:
+            `{datetime} - {level} - {text}`
+    """
+
+    parts = log_line.split(" - ", 2)
+    if len(parts) < 3:
+        logging.warning(f"Incorrect log format for line: {log_line}")
+        return
+    
+    date_time = parts[0].strip()
+    level = parts[1].strip().lower()
+    text = parts[2].strip()
+
+    try:
+        date_time = datetime.strptime(date_time, '%Y-%m-%d %H:%M:%S,%f')
+        level = EventLevel(level)
+    except ValueError as e:
+        logging.error(f"Error parsing log line: {log_line} - {e}")
+        return
+
+    logging.info(f"Sending log to Elasticsearch: {log_line}")
+    event = Event(date_time=date_time, log_level=level.value, text_content=text)
+    event.save()
+
+def send_new_logs_to_es(new_content: str):
+    lines = new_content.split('\n')
+    for line in lines:
+        l = line.strip()
+        if len(l) == 0:
+            continue
+        
+        send_log_to_es(line)
+
+class FileChangeHandler(FileSystemEventHandler):
+    def __init__(self, file_path):
+        self.file_path = file_path
+        self.previous_size = 0
+
+    def on_modified(self, event):
+        if event.src_path == self.file_path:
+            current_size = os.path.getsize(self.file_path)
+            if current_size > self.previous_size:
+                with open(self.file_path, 'r') as file:
+                    file.seek(self.previous_size)
+                    new_content = file.read()
+                    send_new_logs_to_es(new_content)
+                self.previous_size = current_size
+
+def monitor_file(file_path):
+    event_handler = FileChangeHandler(file_path)
+    observer = PollingObserver(timeout=polling_interval)
+    observer.schedule(event_handler, os.path.dirname(file_path), recursive=False)
+    observer.start()
+    
+    logging.info(f"Monitoring changes in {file_path}...")
+    
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    except Exception as e:
+        logging.error(f"Error in monitoring file: {e}")
+    
+    observer.join()
+
+if __name__ == "__main__":
+    file_path_to_monitor = '/logs/mocker-hub.log'
+    
+    if not os.path.exists(file_path_to_monitor):
+        logging.error(f"File {file_path_to_monitor} does not exist. Exiting.")
+        exit(1)
+
+    monitor_file(file_path_to_monitor)

--- a/log_collector/log_collector.py
+++ b/log_collector/log_collector.py
@@ -69,7 +69,26 @@ def send_new_logs_to_es(new_content: str):
 class FileChangeHandler(FileSystemEventHandler):
     def __init__(self, file_path):
         self.file_path = file_path
-        self.previous_size = 0
+        self.size_file_path = self.file_path + '.meta'
+        self.previous_size = self.load_previous_size()
+
+    def load_previous_size(self):
+        if os.path.exists(self.size_file_path):
+            try:
+                with open(self.size_file_path, 'r') as size_file:
+                    val = int(size_file.read().strip())
+                    logging.info(f"Continuing file {self.file_path} from {val}")
+                    return val
+            except Exception as e:
+                logging.error(f"Error reading size file: {e}. Starting from 0.")
+        return 0
+
+    def save_previous_size(self):
+        try:
+            with open(self.size_file_path, 'w') as size_file:
+                size_file.write(str(self.previous_size))
+        except Exception as e:
+            logging.error(f"Error writing size file: {e}")
 
     def on_modified(self, event):
         if event.src_path == self.file_path:
@@ -80,6 +99,8 @@ class FileChangeHandler(FileSystemEventHandler):
                     new_content = file.read()
                     send_new_logs_to_es(new_content)
                 self.previous_size = current_size
+                self.save_previous_size()
+
 
 def monitor_file(file_path):
     event_handler = FileChangeHandler(file_path)

--- a/log_collector/log_collector.py
+++ b/log_collector/log_collector.py
@@ -27,7 +27,7 @@ try:
     Event.init()
     logging.info("Connected to ElasticSearch!")
 except Exception as e:
-    logging.error(f"Failed to connect to ElasticSearch: {e}")
+    logging.error(f"Failed to connect to ElasticSearch: {str(e)}", exc_info=False)
     exit(1)
 
 def send_log_to_es(log_line: str):
@@ -39,7 +39,7 @@ def send_log_to_es(log_line: str):
 
     parts = log_line.split(" - ", 2)
     if len(parts) < 3:
-        logging.warning(f"Incorrect log format for line: {log_line}")
+        # logging.warning(f"Incorrect log format for line: {log_line}")
         return
     
     date_time = parts[0].strip()
@@ -50,7 +50,7 @@ def send_log_to_es(log_line: str):
         date_time = datetime.strptime(date_time, '%Y-%m-%d %H:%M:%S,%f')
         level = EventLevel(level)
     except ValueError as e:
-        logging.error(f"Error parsing log line: {log_line} - {e}")
+        # logging.error(f"Error parsing log line: {log_line} - {e}")
         return
 
     logging.info(f"Sending log to Elasticsearch: {log_line}")
@@ -100,7 +100,6 @@ class FileChangeHandler(FileSystemEventHandler):
                     send_new_logs_to_es(new_content)
                 self.previous_size = current_size
                 self.save_previous_size()
-
 
 def monitor_file(file_path):
     event_handler = FileChangeHandler(file_path)

--- a/log_collector/requirements.txt
+++ b/log_collector/requirements.txt
@@ -1,0 +1,3 @@
+watchdog==2.1.6
+elasticsearch
+elasticsearch-dsl

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,4 +10,10 @@ COPY ./app /code/app
 
 RUN mkdir -p /code/logs
 
+COPY ./entrypoint.sh /code/entrypoint.sh
+RUN ls -l /code
+RUN chmod +x /code/entrypoint.sh
+
+ENTRYPOINT ["/code/entrypoint.sh"]
+
 CMD ["fastapi", "run", "app/api/main.py", "--port", "8000", "--proxy-headers"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,5 +8,6 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 COPY ./app /code/app
 
-#CMD ["fastapi", "run", "app/api/main.py", "--port", "8000"]
+RUN mkdir -p /code/logs
+
 CMD ["fastapi", "run", "app/api/main.py", "--port", "8000", "--proxy-headers"]

--- a/server/app/api/config/elasticsearch.py
+++ b/server/app/api/config/elasticsearch.py
@@ -5,12 +5,20 @@ from elasticsearch_dsl import connections
 import requests
 from app.api.config.logutil import LOGGER
 
+def get_elasticsearch_address():
+    hostname = os.getenv("ELASTICSEARCH_HOST", "elasticsearch")
+    port = os.getenv("ELASTICSEARCH_PORT", "9200")
+    return f"http://{hostname}:{port}"
+
+
 async def try_to_init_elasticsearch():
     LOGGER.info("Establishing ElasticSearch connection...")
     while True:
         try:
             from app.api.events.event_model import Event
-            es = connections.create_connection(hosts=["http://elasticsearch:9200"])
+            hostname = os.getenv("ELASTICSEARCH_HOST", "elasticsearch")
+            port = os.getenv("ELASTICSEARCH_PORT", "9200")
+            es = connections.create_connection(hosts=[get_elasticsearch_address()])
 
             if es.ping():
                 LOGGER.info(f"Elasticsearch connected successfully")
@@ -24,7 +32,8 @@ async def try_to_init_elasticsearch():
             await asyncio.sleep(seconds)
 
     
-def wait_for_elasticsearch(url="http://elasticsearch:9200", max_retries=30, delay=2):
+def wait_for_elasticsearch(max_retries=30, delay=2):
+    url = get_elasticsearch_address()
     for i in range(max_retries):
         try:
             print(f"Connecting to ElasticSearch ({i+1}/{max_retries})...")

--- a/server/app/api/config/elasticsearch.py
+++ b/server/app/api/config/elasticsearch.py
@@ -22,5 +22,5 @@ async def try_to_init_elasticsearch():
                 raise ConnectionError("Elasticsearch connected but is not reachable")
         except Exception as e:
             seconds = 5
-            LOGGER.error(f"Could not load ElasticSearch: {e}. Retrying in {seconds} seconds...")
+            LOGGER.error(f"Could not load ElasticSearch: {e}. Retrying in {seconds} seconds...", exc_info=False)
             await asyncio.sleep(seconds)

--- a/server/app/api/config/elasticsearch.py
+++ b/server/app/api/config/elasticsearch.py
@@ -1,0 +1,8 @@
+from elasticsearch_dsl import connections
+
+def init_elasticsearch_connection():
+    """
+    NOTE: For each `Document` you want to be indexed in ElasticSearch,
+    you must call its `init()` function _AFTER_ this function.
+    """
+    connections.create_connection(hosts=["http://elasticsearch:9200"])

--- a/server/app/api/config/elasticsearch.py
+++ b/server/app/api/config/elasticsearch.py
@@ -1,8 +1,14 @@
+import os
 from elasticsearch_dsl import connections
 
+
 def init_elasticsearch_connection():
-    """
-    NOTE: For each `Document` you want to be indexed in ElasticSearch,
-    you must call its `init()` function _AFTER_ this function.
-    """
-    connections.create_connection(hosts=["http://elasticsearch:9200"])
+    if os.getenv('mocker_hub_TEST_ENV') is not None:
+        print("[!] Detected mocker_hub_TEST_ENV -> Disabling Elasticsearch for testing")
+        # connections._co.clear()   # Obviously this is bad if we wanna do integration tests...
+    else:
+        """
+        NOTE: For each `Document` you want to be indexed in ElasticSearch,
+        you must call its `init()` function _AFTER_ this function.
+        """
+        connections.create_connection(hosts=["http://elasticsearch:9200"])

--- a/server/app/api/config/elasticsearch.py
+++ b/server/app/api/config/elasticsearch.py
@@ -1,13 +1,11 @@
 import asyncio
 import os
+import time
 from elasticsearch_dsl import connections
+import requests
 from app.api.config.logutil import LOGGER
 
 async def try_to_init_elasticsearch():
-    if os.getenv('mocker_hub_TEST_ENV') is not None:
-        print("[!] Detected mocker_hub_TEST_ENV -> Disabling Elasticsearch for testing")
-        return
-
     LOGGER.info("Establishing ElasticSearch connection...")
     while True:
         try:
@@ -24,3 +22,19 @@ async def try_to_init_elasticsearch():
             seconds = 5
             LOGGER.error(f"Could not load ElasticSearch: {e}. Retrying in {seconds} seconds...", exc_info=False)
             await asyncio.sleep(seconds)
+
+    
+def wait_for_elasticsearch(url="http://elasticsearch:9200", max_retries=30, delay=2):
+    for i in range(max_retries):
+        try:
+            print(f"Connecting to ElasticSearch ({i+1}/{max_retries})...")
+            response = requests.get(f"{url}/_cluster/health")
+            if response.status_code == 200:
+                print("Connected to ElasticSearch")
+                return True
+        except requests.ConnectionError as e:
+            print(f"Failed {str(e)}")
+            pass
+        time.sleep(delay)
+    print(f"Failed to wait for ElasticSearch ({max_retries} retries, {delay} delay) :/")
+    return False

--- a/server/app/api/config/elasticsearch.py
+++ b/server/app/api/config/elasticsearch.py
@@ -1,14 +1,26 @@
+import asyncio
 import os
 from elasticsearch_dsl import connections
+from app.api.config.logutil import LOGGER
 
-
-def init_elasticsearch_connection():
+async def try_to_init_elasticsearch():
     if os.getenv('mocker_hub_TEST_ENV') is not None:
         print("[!] Detected mocker_hub_TEST_ENV -> Disabling Elasticsearch for testing")
-        # connections._co.clear()   # Obviously this is bad if we wanna do integration tests...
-    else:
-        """
-        NOTE: For each `Document` you want to be indexed in ElasticSearch,
-        you must call its `init()` function _AFTER_ this function.
-        """
-        connections.create_connection(hosts=["http://elasticsearch:9200"])
+        return
+
+    LOGGER.info("Establishing ElasticSearch connection...")
+    while True:
+        try:
+            from app.api.events.event_model import Event
+            es = connections.create_connection(hosts=["http://elasticsearch:9200"])
+
+            if es.ping():
+                LOGGER.info(f"Elasticsearch connected successfully")
+                Event.init()
+                return
+            else:
+                raise ConnectionError("Elasticsearch connected but is not reachable")
+        except Exception as e:
+            seconds = 5
+            LOGGER.error(f"Could not load ElasticSearch: {e}. Retrying in {seconds} seconds...")
+            await asyncio.sleep(seconds)

--- a/server/app/api/config/logutil.py
+++ b/server/app/api/config/logutil.py
@@ -1,5 +1,6 @@
 import logging
 from logging.handlers import RotatingFileHandler
+import os
 import sys
 
 LOGGER = logging.getLogger()  # If later on we want to ignore the default log messages, we can add a name here...
@@ -11,14 +12,17 @@ backup_count = 3
 
 formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 
-# Log to file.
+# TODO: We probably want to include logging to file in integration tests, should
+# we ever test ES<->Server. I'm not sure how to do that though.
+if os.getenv('mocker_hub_TEST_ENV') is None:
+    # Log to file.
 
-rotating_handler = RotatingFileHandler(log_file, maxBytes=max_log_size, backupCount=backup_count)
-rotating_handler.setFormatter(formatter)
-LOGGER.addHandler(rotating_handler)
+    rotating_handler = RotatingFileHandler(log_file, maxBytes=max_log_size, backupCount=backup_count)
+    rotating_handler.setFormatter(formatter)
+    LOGGER.addHandler(rotating_handler)
 
-# Log to stdout.
+    # Log to stdout.
 
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setFormatter(formatter)
-LOGGER.addHandler(console_handler)
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    LOGGER.addHandler(console_handler)

--- a/server/app/api/config/logutil.py
+++ b/server/app/api/config/logutil.py
@@ -1,5 +1,6 @@
 import logging
 from logging.handlers import RotatingFileHandler
+import sys
 
 LOGGER = logging.getLogger()  # If later on we want to ignore the default log messages, we can add a name here...
 LOGGER.setLevel(logging.DEBUG)
@@ -8,11 +9,16 @@ log_file = '/code/logs/mocker-hub.log'
 max_log_size = 5 * 1024 * 1024
 backup_count = 3
 
-rotating_handler = RotatingFileHandler(
-    log_file, maxBytes=max_log_size, backupCount=backup_count
-)
-
 formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-rotating_handler.setFormatter(formatter)
 
+# Log to file.
+
+rotating_handler = RotatingFileHandler(log_file, maxBytes=max_log_size, backupCount=backup_count)
+rotating_handler.setFormatter(formatter)
 LOGGER.addHandler(rotating_handler)
+
+# Log to stdout.
+
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setFormatter(formatter)
+LOGGER.addHandler(console_handler)

--- a/server/app/api/config/logutil.py
+++ b/server/app/api/config/logutil.py
@@ -12,17 +12,15 @@ backup_count = 3
 
 formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 
-# TODO: We probably want to include logging to file in integration tests, should
-# we ever test ES<->Server. I'm not sure how to do that though.
+# Log to file.
+
+rotating_handler = RotatingFileHandler(log_file, maxBytes=max_log_size, backupCount=backup_count)
+rotating_handler.setFormatter(formatter)
+LOGGER.addHandler(rotating_handler)
+
+# Log to stdout.
+
 if os.getenv('mocker_hub_TEST_ENV') is None:
-    # Log to file.
-
-    rotating_handler = RotatingFileHandler(log_file, maxBytes=max_log_size, backupCount=backup_count)
-    rotating_handler.setFormatter(formatter)
-    LOGGER.addHandler(rotating_handler)
-
-    # Log to stdout.
-
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(formatter)
     LOGGER.addHandler(console_handler)

--- a/server/app/api/config/logutil.py
+++ b/server/app/api/config/logutil.py
@@ -1,0 +1,18 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+LOGGER = logging.getLogger()  # If later on we want to ignore the default log messages, we can add a name here...
+LOGGER.setLevel(logging.DEBUG)
+
+log_file = '/code/logs/mocker-hub.log'
+max_log_size = 5 * 1024 * 1024
+backup_count = 3
+
+rotating_handler = RotatingFileHandler(
+    log_file, maxBytes=max_log_size, backupCount=backup_count
+)
+
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+rotating_handler.setFormatter(formatter)
+
+LOGGER.addHandler(rotating_handler)

--- a/server/app/api/events/event_controller.py
+++ b/server/app/api/events/event_controller.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 from app.api.events.event_dto import EventDTO
 from app.api.events.event_service import EventService
 from app.api.events.event_model import EventLevel
+from app.api.config.exception_handler import InvalidInputException
 
 router = APIRouter(prefix="/events", tags=["events"])
 
@@ -11,6 +12,11 @@ router = APIRouter(prefix="/events", tags=["events"])
 async def search_events_route(log_level: str, start_date: str = None, end_date: str = None):
     event_service = EventService()
 
-    log_level = EventLevel(log_level)
+    try:
+        log_level = EventLevel(log_level)
+    except ValueError:
+        possible_values = [lvl.value for lvl in EventLevel]
+        raise InvalidInputException(f"Unknown log level '{log_level}', supported values are {possible_values}")
+
     events = event_service.search(log_level, start_date, end_date)
     return events

--- a/server/app/api/events/event_controller.py
+++ b/server/app/api/events/event_controller.py
@@ -1,0 +1,16 @@
+from typing import List
+from fastapi import APIRouter
+
+from app.api.events.event_dto import EventDTO
+from app.api.events.event_service import EventService
+from app.api.events.event_model import EventLevel
+
+router = APIRouter(prefix="/events", tags=["events"])
+
+@router.get("/", response_model=List[EventDTO], status_code=200, summary="Something...")
+async def search_events_route(log_level: str, start_date: str = None, end_date: str = None):
+    event_service = EventService()
+
+    log_level = EventLevel(log_level)
+    events = event_service.search(log_level, start_date, end_date)
+    return events

--- a/server/app/api/events/event_controller.py
+++ b/server/app/api/events/event_controller.py
@@ -1,17 +1,15 @@
 from typing import List
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.api.events.event_dto import EventDTO
-from app.api.events.event_service import EventService
+from app.api.events.event_service import EventService, get_event_service
 from app.api.events.event_model import EventLevel
 from app.api.config.exception_handler import InvalidInputException
 
 router = APIRouter(prefix="/events", tags=["events"])
 
 @router.get("/", response_model=List[EventDTO], status_code=200, summary="Something...")
-async def search_events_route(log_level: str, start_date: str = None, end_date: str = None):
-    event_service = EventService()
-
+async def search_events_route(log_level: str, start_date: str = None, end_date: str = None, event_service: EventService = Depends(get_event_service)):
     try:
         log_level = EventLevel(log_level)
     except ValueError:

--- a/server/app/api/events/event_dto.py
+++ b/server/app/api/events/event_dto.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+class EventDTO(BaseModel):
+    date_time: datetime
+    log_level: str
+    text_content: str

--- a/server/app/api/events/event_model.py
+++ b/server/app/api/events/event_model.py
@@ -1,0 +1,17 @@
+from enum import Enum
+from elasticsearch_dsl import Document, Text, Date, Keyword
+
+class EventLevel(Enum):
+    Debug = "debug"
+    Trace = "trace"
+    Info = "info"
+    Warning = "warning"
+    Error = "error"
+
+class Event(Document):
+    date_time = Date()
+    log_level = Keyword()
+    text_content = Text()
+
+    class Index:
+        name = 'events'

--- a/server/app/api/events/event_model.py
+++ b/server/app/api/events/event_model.py
@@ -3,7 +3,6 @@ from elasticsearch_dsl import Document, Text, Date, Keyword
 
 class EventLevel(Enum):
     Debug = "debug"
-    Trace = "trace"
     Info = "info"
     Warning = "warning"
     Error = "error"
@@ -15,3 +14,5 @@ class Event(Document):
 
     class Index:
         name = 'events'
+
+    

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -1,3 +1,4 @@
+import os
 from app.api.events.event_model import Event, EventLevel
 from elasticsearch_dsl import Search
 from datetime import datetime
@@ -9,7 +10,8 @@ class EventService:
 
     def save(self, date_time: datetime, log_level: EventLevel, text_content: str) -> Event:
         event = Event(date_time=date_time, log_level=log_level.value, text_content=text_content)
-        event.save()
+        if os.getenv('mocker_hub_TEST_ENV') is None:
+            event.save()
         return event
 
     def search(self, log_level: EventLevel, start_date: str = None, end_date: str = None):
@@ -24,7 +26,7 @@ class EventService:
             "log_level": hit.log_level, 
             "text_content": hit.text_content
         } for hit in response]
-    
+  
 
 def get_event_service() -> EventService:
     return EventService()

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -49,7 +49,6 @@ class EventService:
         else:
             raise ValueError(f"Unknown event level: {event_level}")
 
-  
 
 def get_event_service() -> EventService:
     return EventService()

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Type
 from app.api.events.event_model import Event, EventLevel
 from elasticsearch_dsl import Search
 from datetime import datetime
@@ -10,8 +11,16 @@ class EventService:
     def __init__(self):
         ...
 
-    def save(self, date_time: datetime, log_level: EventLevel, text_content: str):
-        LOGGER.log(self.event_level_to_log_level(log_level), text_content)
+    def log_read(self, user_id: int | None, entity_type: Type, entity_identifier: int | str):
+        """
+        Log case when user tries to access an entity.
+        Example: `log_read(1, Repository, 'user1/reponame')`
+        """
+        self.log(EventLevel.Info, f"User {user_id} wants to read {entity_type.__name__} {entity_identifier}")
+
+    def log(self, log_level: EventLevel, text_content: str):
+        """Generic log function."""
+        LOGGER.log(self._event_level_to_log_level(log_level), text_content)
 
     def search(self, log_level: EventLevel, start_date: str = None, end_date: str = None):
         s = Search(index=Event.Index.name).filter("term", log_level=log_level.value)
@@ -26,7 +35,7 @@ class EventService:
             "text_content": hit.text_content
         } for hit in response]
     
-    def event_level_to_log_level(self, event_level: EventLevel):
+    def _event_level_to_log_level(self, event_level: EventLevel):
         if event_level == EventLevel.Debug:
             return logging.DEBUG
         elif event_level == EventLevel.Info:

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -27,8 +27,10 @@ class EventService:
         
         if start_date and end_date:
             s = s.filter("range", date_time={"gte": start_date, "lte": end_date})
-
-        s = s.sort({"date_time": {"order": "desc"}})
+        elif start_date:
+            s = s.filter("range", date_time={"gte": start_date})
+        elif end_date:
+            s = s.filter("range", date_time={"lte": end_date})
         
         response = s.execute()
         return [{

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -1,0 +1,16 @@
+from app.api.events.event_model import Event, EventLevel
+from elasticsearch_dsl import Search
+from datetime import datetime
+
+
+class EventService:
+    def __init__(self):
+        ...
+
+    def save(self, date_time: datetime, log_level: EventLevel, text_content: str) -> Event:
+        event = Event(date_time=date_time, log_level=str(log_level), text_content=text_content)
+        event.save()
+        return event
+
+def get_event_service() -> EventService:
+    return EventService()

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -27,6 +27,8 @@ class EventService:
         
         if start_date and end_date:
             s = s.filter("range", date_time={"gte": start_date, "lte": end_date})
+
+        s = s.sort({"date_time": {"order": "desc"}})
         
         response = s.execute()
         return [{

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -13,11 +13,6 @@ class EventService:
     def save(self, date_time: datetime, log_level: EventLevel, text_content: str):
         LOGGER.log(self.event_level_to_log_level(log_level), text_content)
 
-        # event = Event(date_time=date_time, log_level=log_level.value, text_content=text_content)
-        # if os.getenv('mocker_hub_TEST_ENV') is None:
-        #     event.save()
-        # return event
-
     def search(self, log_level: EventLevel, start_date: str = None, end_date: str = None):
         s = Search(index=Event.Index.name).filter("term", log_level=log_level.value)
         

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -1,7 +1,9 @@
+import logging
 import os
 from app.api.events.event_model import Event, EventLevel
 from elasticsearch_dsl import Search
 from datetime import datetime
+from app.api.config.logutil import LOGGER
 
 
 class EventService:
@@ -9,6 +11,8 @@ class EventService:
         ...
 
     def save(self, date_time: datetime, log_level: EventLevel, text_content: str) -> Event:
+        LOGGER.log(self.event_level_to_log_level(log_level), text_content)
+
         event = Event(date_time=date_time, log_level=log_level.value, text_content=text_content)
         if os.getenv('mocker_hub_TEST_ENV') is None:
             event.save()
@@ -26,6 +30,19 @@ class EventService:
             "log_level": hit.log_level, 
             "text_content": hit.text_content
         } for hit in response]
+    
+    def event_level_to_log_level(self, event_level: EventLevel):
+        if event_level == EventLevel.Debug:
+            return logging.DEBUG
+        elif event_level == EventLevel.Info:
+            return logging.INFO
+        elif event_level == EventLevel.Warning:
+            return logging.WARNING
+        elif event_level == EventLevel.Error:
+            return logging.ERROR
+        else:
+            raise ValueError(f"Unknown event level: {event_level}")
+
   
 
 def get_event_service() -> EventService:

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -10,13 +10,13 @@ class EventService:
     def __init__(self):
         ...
 
-    def save(self, date_time: datetime, log_level: EventLevel, text_content: str) -> Event:
+    def save(self, date_time: datetime, log_level: EventLevel, text_content: str):
         LOGGER.log(self.event_level_to_log_level(log_level), text_content)
 
-        event = Event(date_time=date_time, log_level=log_level.value, text_content=text_content)
-        if os.getenv('mocker_hub_TEST_ENV') is None:
-            event.save()
-        return event
+        # event = Event(date_time=date_time, log_level=log_level.value, text_content=text_content)
+        # if os.getenv('mocker_hub_TEST_ENV') is None:
+        #     event.save()
+        # return event
 
     def search(self, log_level: EventLevel, start_date: str = None, end_date: str = None):
         s = Search(index=Event.Index.name).filter("term", log_level=log_level.value)

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -8,9 +8,23 @@ class EventService:
         ...
 
     def save(self, date_time: datetime, log_level: EventLevel, text_content: str) -> Event:
-        event = Event(date_time=date_time, log_level=str(log_level), text_content=text_content)
+        event = Event(date_time=date_time, log_level=log_level.value, text_content=text_content)
         event.save()
         return event
+
+    def search(self, log_level: EventLevel, start_date: str = None, end_date: str = None):
+        s = Search(index=Event.Index.name).filter("term", log_level=log_level.value)
+        
+        if start_date and end_date:
+            s = s.filter("range", date_time={"gte": start_date, "lte": end_date})
+        
+        response = s.execute()
+        return [{
+            "date_time": hit.date_time, 
+            "log_level": hit.log_level, 
+            "text_content": hit.text_content
+        } for hit in response]
+    
 
 def get_event_service() -> EventService:
     return EventService()

--- a/server/app/api/main.py
+++ b/server/app/api/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from app.api.config.initialize import init_create_tables, configure_cors, init_dummy_data, init_superadmin
 from app.api.config.exception_handler import register_exception_handler
 import app.api.events
+import app.api.events.event_controller
 import app.api.user.user_controller
 import app.api.repo.repo_controller
 import app.api.org.org_controller
@@ -18,6 +19,7 @@ the_router.include_router(app.api.user.user_controller.router)
 the_router.include_router(app.api.repo.repo_controller.router)
 the_router.include_router(app.api.org.org_controller.router)
 the_router.include_router(app.api.team.team_controller.router)
+the_router.include_router(app.api.events.event_controller.router)
 
 internal_registry_router = APIRouter()
 internal_registry_router.include_router(app.api.registry.registry_controller.router)

--- a/server/app/api/main.py
+++ b/server/app/api/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from fastapi import APIRouter, FastAPI
 from contextlib import asynccontextmanager
@@ -11,7 +12,7 @@ import app.api.org.org_controller
 import app.api.registry.registry_controller
 import app.api.team.team_controller
 from app.api.config.cache import init_cache
-from app.api.config.elasticsearch import init_elasticsearch_connection
+from app.api.config.elasticsearch import try_to_init_elasticsearch
 from app.api.events.event_model import Event
 
 
@@ -36,9 +37,7 @@ async def lifespan(app: FastAPI):
     init_create_tables()
     init_cache()
     init_superadmin()
-    init_elasticsearch_connection()
-    if os.getenv('mocker_hub_TEST_ENV') is None:
-        Event.init()
+    asyncio.create_task(try_to_init_elasticsearch())
     yield
 
 app = FastAPI(lifespan=lifespan)

--- a/server/app/api/main.py
+++ b/server/app/api/main.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import APIRouter, FastAPI
 from contextlib import asynccontextmanager
 from app.api.config.initialize import init_create_tables, configure_cors, init_dummy_data, init_superadmin
@@ -36,7 +37,8 @@ async def lifespan(app: FastAPI):
     init_cache()
     init_superadmin()
     init_elasticsearch_connection()
-    Event.init()
+    if os.getenv('mocker_hub_TEST_ENV') is None:
+        Event.init()
     yield
 
 app = FastAPI(lifespan=lifespan)

--- a/server/app/api/main.py
+++ b/server/app/api/main.py
@@ -2,12 +2,16 @@ from fastapi import APIRouter, FastAPI
 from contextlib import asynccontextmanager
 from app.api.config.initialize import init_create_tables, configure_cors, init_dummy_data, init_superadmin
 from app.api.config.exception_handler import register_exception_handler
+import app.api.events
 import app.api.user.user_controller
 import app.api.repo.repo_controller
 import app.api.org.org_controller
 import app.api.registry.registry_controller
 import app.api.team.team_controller
 from app.api.config.cache import init_cache
+from app.api.config.elasticsearch import init_elasticsearch_connection
+from app.api.events.event_model import Event
+
 
 the_router = APIRouter()
 the_router.include_router(app.api.user.user_controller.router)
@@ -29,6 +33,8 @@ async def lifespan(app: FastAPI):
     init_create_tables()
     init_cache()
     init_superadmin()
+    init_elasticsearch_connection()
+    Event.init()
     yield
 
 app = FastAPI(lifespan=lifespan)

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -61,7 +61,7 @@ def get_repo_by_canonical_name(
     user_id = get_id_from_jwt_optional(jwt)
     repo = repo_service.find_by_canonical_name(repo_canonical_name)
 
-    event_service.save(datetime.now(), EventLevel.Info, f"User {user_id} GET repository {repo_canonical_name}")
+    event_service.log_read(user_id, Repository, repo_canonical_name)
 
     if not access_control_service.has_read_access(user_id, repo.id):
         raise NotFoundException(Repository, repo_canonical_name)

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -61,7 +61,7 @@ def get_repo_by_canonical_name(
     user_id = get_id_from_jwt_optional(jwt)
     repo = repo_service.find_by_canonical_name(repo_canonical_name)
 
-    event_service.save(datetime.now(), EventLevel.Trace, f"User {user_id} GET repository {repo_canonical_name}")
+    event_service.save(datetime.now(), EventLevel.Info, f"User {user_id} GET repository {repo_canonical_name}")
 
     if not access_control_service.has_read_access(user_id, repo.id):
         raise NotFoundException(Repository, repo_canonical_name)

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 from fastapi import APIRouter, Depends
 
@@ -11,6 +12,8 @@ from app.api.org.org_service import OrganizationService, get_org_service
 from app.api.config.exception_handler import NotFoundException, AccessDeniedException
 from app.api.repo.repo_model import Repository
 from app.api.access_control.access_control_service import AccessControlService, get_access_control_service
+from app.api.events.event_service import EventService, get_event_service
+from app.api.events.event_model import EventLevel
 
 router = APIRouter(prefix="/repositories", tags=["repositories"])
 
@@ -51,10 +54,14 @@ def get_repo_by_canonical_name(
     jwt: JWTDepOptional, 
     repo_canonical_name: str, 
     repo_service: RepositoryService = Depends(get_repo_service),
-    access_control_service: AccessControlService = Depends(get_access_control_service)):
+    access_control_service: AccessControlService = Depends(get_access_control_service),
+    event_service: EventService = Depends(get_event_service)
+    ):
 
     user_id = get_id_from_jwt_optional(jwt)
     repo = repo_service.find_by_canonical_name(repo_canonical_name)
+
+    event_service.save(datetime.now(), EventLevel.Trace, f"User {user_id} GET repository {repo_canonical_name}")
 
     if not access_control_service.has_read_access(user_id, repo.id):
         raise NotFoundException(Repository, repo_canonical_name)

--- a/server/app/tests/README.md
+++ b/server/app/tests/README.md
@@ -12,25 +12,15 @@ so instead I've created an `.env` in project root:
 RUN_TESTS=true
 ```
 
-And then `docker compose up --build`.
-
-When you're done testing, remove the ENV variable.
-
----
----
----
----
-## Old (TODO: Remove)
-
-1) Position yourself to the root of this repository. We need to do this because of ./volume-server-cfg.
+Build the container:
 
 ```sh
-user:.../mocker-hub/server/app/tests$ cd ../../../
-user:.../mocker-hub$
+# --abort-on-container-exit will exit as soon as backend exits
+# --exit-code-from backend will return backend's exit code
+#
+# We need this in CI/CD.
+
+docker compose up --build backend --abort-on-container-exit --exit-code-from backend
 ```
 
-2) Run the tests. `-s` is to show stdout from `print()`.
-
-```sh
-mocker_hub_TEST_ENV=1 pytest server/app/tests/ -s
-```
+When you're done testing and want to run MockerHub regularly, remove the ENV variable.

--- a/server/app/tests/README.md
+++ b/server/app/tests/README.md
@@ -1,5 +1,27 @@
 ## Running the tests
 
+To run tests, do
+```sh
+RUN_TESTS=true docker compose up --build
+```
+
+However, I've been having issues with this on WSL,
+so instead I've created an `.env` in project root:
+
+```sh
+RUN_TESTS=true
+```
+
+And then `docker compose up --build`.
+
+When you're done testing, remove the ENV variable.
+
+---
+---
+---
+---
+## Old (TODO: Remove)
+
 1) Position yourself to the root of this repository. We need to do this because of ./volume-server-cfg.
 
 ```sh

--- a/server/app/tests/test_user.py
+++ b/server/app/tests/test_user.py
@@ -11,6 +11,7 @@ from app.api.user.user_repo import UserRepo
 from app.api.user.user_service import UserService
 from app.api.config.exception_handler import NotFoundException, UserException, FieldTakenException
 from app.api.main import app
+from app.api.config.elasticsearch import wait_for_elasticsearch
 
 @pytest.fixture
 def mock_session():
@@ -242,8 +243,8 @@ def test_add_admin___integration():
         assert response.status_code == 400
         
 def test_add___integration():
-
     with TestClient(app) as client:
+        assert wait_for_elasticsearch()
 
         def add_user(username: str | None, status_code: int | None) -> dict:
             data = {

--- a/server/app/tests/test_user.py
+++ b/server/app/tests/test_user.py
@@ -11,7 +11,6 @@ from app.api.user.user_repo import UserRepo
 from app.api.user.user_service import UserService
 from app.api.config.exception_handler import NotFoundException, UserException, FieldTakenException
 from app.api.main import app
-from app.api.config.elasticsearch import wait_for_elasticsearch
 
 @pytest.fixture
 def mock_session():
@@ -244,8 +243,6 @@ def test_add_admin___integration():
         
 def test_add___integration():
     with TestClient(app) as client:
-        assert wait_for_elasticsearch()
-
         def add_user(username: str | None, status_code: int | None) -> dict:
             data = {
                 "username": username,

--- a/server/app/tests/test_z_events.py
+++ b/server/app/tests/test_z_events.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+
+from app.api.main import app
+from app.api.config.elasticsearch import wait_for_elasticsearch
+
+def test_temp___integration():
+    with TestClient(app) as client:
+        assert wait_for_elasticsearch()
+
+        def search_for_something(level: str):
+            response = client.get(f"/api/v1/events/?log_level={level}")
+            return response
+        
+        res = search_for_something("info")
+        assert res.is_success
+        assert len(res.json()) > 0

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Starting FastAPI app..."
+fastapi run app/api/main.py --port 8000 --proxy-headers

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 
-echo "Starting FastAPI app..."
-fastapi run app/api/main.py --port 8000 --proxy-headers
+echo "RUN_TESTS: $RUN_TESTS"  # Debugging line
 
+if [ "$RUN_TESTS" = "true" ]; then
+  echo "Running tests..."
+  ls -l
+  mocker_hub_TEST_ENV=1 pytest /code/app/tests -s --maxfail=1 --disable-warnings --tb=short
 
-# if [ "$RUN_TESTS" = "true" ]; then
-#   echo "Running tests..."
-#   pytest --maxfail=1 --disable-warnings --tb=short
-
-#   if [ $? -eq 0 ]; then
-#     echo "Tests passed successfully!"
-#   else
-#     echo "Tests failed!"
-#     exit 1
-#   fi
-# else
-#   echo "Starting FastAPI app..."
-#   fastapi run app/api/main.py --port 8000 --proxy-headers
-# fi
+  if [ $? -eq 0 ]; then
+    echo "Tests passed successfully!"
+    exit 0
+  else
+    echo "Tests failed!"
+    exit 1
+  fi
+else
+  echo "Starting FastAPI app..."
+  fastapi run app/api/main.py --port 8000 --proxy-headers
+fi

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -2,3 +2,19 @@
 
 echo "Starting FastAPI app..."
 fastapi run app/api/main.py --port 8000 --proxy-headers
+
+
+# if [ "$RUN_TESTS" = "true" ]; then
+#   echo "Running tests..."
+#   pytest --maxfail=1 --disable-warnings --tb=short
+
+#   if [ $? -eq 0 ]; then
+#     echo "Tests passed successfully!"
+#   else
+#     echo "Tests failed!"
+#     exit 1
+#   fi
+# else
+#   echo "Starting FastAPI app..."
+#   fastapi run app/api/main.py --port 8000 --proxy-headers
+# fi

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,3 +14,4 @@ pytest
 httpx
 
 pillow
+elasticsearch-dsl


### PR DESCRIPTION
Closes #32 

This Pull request implements ElasticSearch.

# Manual testing

1. Open [swagger](localhost:8000/docs).
2. Make sure you have dummy data (`api/v1/dummy`).
3. Search repo by name `user1/python` (`api/v1/repositories/name`).
4. Search for events using the demo endpoint with level=`info` (`api/v1/events/?log_level=info`). You should see the 10 most recents logs (one of which should read `User [id or None] wants to read Repository user1/python`).

# Walkthrough

Here's a summary-walkthrough of the implementation:

1. In `compose.yaml`, I've added the `elasticsearch` service. The memory has been limited to 256MB in hopes of speeding things up (the default is 1GB). I've also added other configuration options that supposedly speed things up. What they actually do - I'm not sure.

6. The `backend` attempts to connect to ES periodically using `async wait_for_elasticsearch()`. Since ES can take some time to boot up, it wouldn't make sense to crash the backend because ES isn't ready. The server uses ES for a small subset of features anyway (they aren't implemented yet). 

7. Additionally, the "find repository by canonical name" endpoint will log the event (later on, we will want to log _everything_, but this is just a demo).

8. The `backend` writes logs to STDOUT and a file. The file is in `/logs/mocker-hub.log`.

9. The `log-collector` service periodically checks for the log file and sends new entries to ES. I've tried using 3rd party solutions like `filebeat` and `vector`, but couldn't get either of them to work, so after a day of trial and error I gave up and my own.

10. You can do a basic search request to ES. Specify log level (e.g. `info`) and it should return logs if ES has any in its index.

11. The way we run tests has changed. You now have to build the containers. This is because integration testing `elasticsearch` _requires_ the ES service. Besides, we may need it for other services in the future. Check `tests/README.md` for how to do it. I've made sure that CI/CD works properly so that docker compose shuts down after server exits (which happens when tests finish or on error). 