### PR TITLE
Containerize web app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18 AS build
+WORKDIR /app
+COPY ./client/package.json ./client/package-lock.json ./
+RUN npm install
+COPY ./client ./
+RUN npm run build
+
+FROM nginx
+COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,29 @@
-FROM node:18 AS build
-WORKDIR /app
-COPY ./client/package.json ./client/package-lock.json ./
-RUN npm install
-COPY ./client ./
-RUN npm run build
+##############################
+#               
+# TEST ENVIRIONMENT
+#
+##############################
+# Comment in/out when ready
 
 FROM nginx
 COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
+
+##############################
+#               
+# PRODUCTION ENVIRIONMENT
+#
+##############################
+# Comment in/out when ready
+
+# FROM node:18 AS build
+# WORKDIR /app
+# COPY ./client/package.json ./client/package-lock.json ./
+# RUN npm install
+# COPY ./client ./
+# RUN npm run build
+
+# FROM nginx
+# COPY --from=build /app/dist /usr/share/nginx/html
+# COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
+# EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@
 
 3) Use debug data while developing. On the first run, while the database is empty, visit [localhost:8000/api/v1/dummy](localhost:8000/api/v1/dummy) (do this just once).
 
+### Nginx and the web app
+
+During development, run the `client/` app locally using `npm run dev`.
+
+In production, you should use nginx as the web app server. To do this, comment in the test environment and comment out the production environment in the root Dockerfile.
+
 ## Access points
 
 You can access the server at [localhost:8000](http://localhost:8000/docs).

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,19 @@
+node_modules/
+
+/build
+/dist
+
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+.DS_Store
+Thumbs.db
+
+.vscode/
+.idea/
+*.sublime-workspace
+*.sublime-project
+
+.env
+.env.* # In case you have different environment files like .env.production

--- a/client/src/api/user.api.ts
+++ b/client/src/api/user.api.ts
@@ -1,6 +1,5 @@
 import { AxiosResponse } from "axios";
 import { axiosInstance } from "../util/http";
-import { getJWTStringOrNull } from "../util/localstorage";
 
 export interface UserRegisterDTO {
     email: string,

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import { NavLink } from "react-router";
 import "./Navbar.css";
-import { getJwtRole } from "../util/localstorage";
 import { useAuthStore } from "../util/store";
 
 export function Navbar() {

--- a/client/src/pages/UserLogin.tsx
+++ b/client/src/pages/UserLogin.tsx
@@ -4,7 +4,7 @@ import './UserLogin.css';
 import { TokenDTO, UserLoginDTO, UserService } from '../api/user.api';
 import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
-import { getJwtId, getJwtMustChangePassword, getJwtRole, getJwtUsername, setJWT } from '../util/localstorage';
+import { getJwtMustChangePassword, getJwtRole, getJwtUsername, setJWT } from '../util/localstorage';
 import { useAuthStore } from '../util/store';
 
 export const UserLogin = () => {

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - db
       - cache
-      - nginx
+      # - nginx
       - elasticsearch
       - distribution
       - log_collector
@@ -70,13 +70,15 @@ services:
     ports:
       - "8002:8080"
 
-  nginx:
-    build: ./nginx/
+  nginx:  # And frontend.
+    build:
+      context: .
+      dockerfile: ./Dockerfile
     ports:
       - "80:80"
-    volumes:
-      - ./images:/usr/share/nginx/html/images
-
+    depends_on:
+      - backend
+  
   cache:
     image: redis:alpine3.20
     restart: always

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,0 @@
-FROM nginx
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,6 +2,11 @@ server {
     listen       80;
     server_name  localhost;
 
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+    }
+
     location /api/ {
         proxy_pass http://backend:8000/api/v1/;
     }


### PR DESCRIPTION
Closes #34 

**The code on this branch by does NOT build the web app inside Docker**

This is because it takes way too much time to:
1) Pull the node image (this happens only once but still)
2) Install dependencies from `package.json`
3) Build the app
4) Copy all build files inside the container

On my machine, it can take up to 2 minutes each time, which is unacceptable during development when I'm doing fast iterations.

---

So, to circumvent this, the nginx dockerfile (which is now at project root), currently just builds nginx using its config. If you want the web app, run it locally (`npm run dev`) _or_ uncomment the second part of the dockerfile (and comment the first part).

Ideally, you shouldn't have to do this ever during development, but once the app is ready, we can easily migrate. I welcome you to test it out just once, if nothing then at least to verify this works on your end and to also pull the node image.

If you're accessing the web app through nginx, you have to use `127.0.0.1` and not `localhost`.