### PR TITLE
Authorization for mounting blobs enhancement

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,6 +23,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r server/requirements.txt
+    
+    - name: Unpack certificates
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y unrar
+        unrar x distribution/certs/certs.rar distribution/certs/
 
     - name: Create .env file
       run: |

--- a/server/app/api/registry/registry_controller.py
+++ b/server/app/api/registry/registry_controller.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException, Request
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
 
 from app.api.registry.registry_utils import decode_auth_header
 from app.api.registry.registry_service import RegistryService, get_registry_service
@@ -10,7 +11,7 @@ router = APIRouter(prefix="/registry", tags=["dockerhub-registry"])
 def registry_endpoint(
     request: Request, 
     registry_service: RegistryService = Depends(get_registry_service),
-    scope: str | None = None,
+    scopes: List[str] | None = Query(default=None, alias="scope"),
     service: str | None = None):
 
     authorization_header = request.headers.get("Authorization")
@@ -22,7 +23,7 @@ def registry_endpoint(
     auth_token = authorization_header.split(" ")[1]
     username, password = decode_auth_header(auth_token)
 
-    return registry_service.handle_registry_request(username, password, scope, service)
+    return registry_service.handle_registry_request(username, password, scopes, service)
 
 @router.api_route("/notifications", methods=["POST", "PUT"], summary="Webhook for Docker Registry")
 def registry_notification_endpoint(data: dict, registry_service: RegistryService = Depends(get_registry_service)):

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -55,30 +55,32 @@ class RegistryService:
             user = self.user_service.find_by_username(username)
             repo = self.repo_service.find_by_canonical_name(action.repo_canonical_name)
 
-            # Case 1 - User requested push operation on the repo.
+            for operation in action.operations:
 
-            if RegistryActionOperation.push in action.operations:
-                # This will cover all the neccessary cases:
-                #  - repo doesn't exist
-                #  - user doesn't exist
-                #  - user doesn't have access
-                #  - etc.
+                # Case 1 - User requested push operation on the repo.
 
-                can_write = self.access_control_service.has_write_access(user.id, repo.id)
-                if not can_write:
-                    raise HTTPException(status_code=401, detail=f"User {user.username} cannot push to repo {repo.canonical_name}")      
-                
-            # Case 2 - User requested pull operation on the repo.
+                if operation == RegistryActionOperation.push:
+                    # This will cover all the neccessary cases:
+                    #  - repo doesn't exist
+                    #  - user doesn't exist
+                    #  - user doesn't have access
+                    #  - etc.
 
-            elif RegistryActionOperation.pull in action.operations:
-                can_read = self.access_control_service.has_read_access(user.id, repo.id)
-                if not can_read:
-                    raise HTTPException(status_code=401, detail=f"User {user.username} cannot pull from repo {repo.canonical_name}")
-                
-            # Case 3 - Unknown operation.
+                    can_write = self.access_control_service.has_write_access(user.id, repo.id)
+                    if not can_write:
+                        raise HTTPException(status_code=401, detail=f"User {user.username} cannot push to repo {repo.canonical_name}")      
+                    
+                # Case 2 - User requested pull operation on the repo.
 
-            else:
-                raise HTTPException(status_code=400, detail=f"Unknown operations {action.operations}")
+                elif operation == RegistryActionOperation.pull:
+                    can_read = self.access_control_service.has_read_access(user.id, repo.id)
+                    if not can_read:
+                        raise HTTPException(status_code=401, detail=f"User {user.username} cannot pull from repo {repo.canonical_name}")
+                    
+                # Case 3 - Unknown operation.
+
+                else:
+                    raise HTTPException(status_code=400, detail=f"Unknown operations {action.operations}")
             
         # Create the JWT.
             

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -1,8 +1,9 @@
+from typing import List
 from fastapi import Depends, HTTPException
 from sqlmodel import Session
 from app.api.config.database import get_database
 from app.api.access_control.access_control_service import AccessControlService
-from app.api.registry.registry_utils import parse_scope, build_jwt_for_docker_registry
+from app.api.registry.registry_utils import parse_scopes, build_jwt_for_docker_registry
 from app.api.user.user_service import UserService
 from app.api.repo.repo_service import RepositoryService
 from app.api.registry.registry_dto import RegistryActionOperation
@@ -40,51 +41,52 @@ class RegistryService:
         print(f"User '{username}' completed '{action}' of repository '{repo_name}' with tag '{tag}'")
 
 
-    def handle_registry_request(self, username: str, password: str, scope: str | None, service: str | None):
+    def handle_registry_request(self, username: str, password: str, scopes: List[str] | None, service: str | None):
         # User with the provided credentials must exist.
 
         if not self.user_service.exists_with_credentials(username, password):
             raise HTTPException(status_code=401, detail="Invalid username or password")
         
-        # Scope is defined, therefore this is a push/pull request. If the scope
-        # isn't defined, this is a login request, so we can skip to creating the
+        # Scopes are defined, therefore these are push/pull requests. If scopes
+        # aren't defined, this is a login request, so we can skip to creating the
         # JWT.
 
-        if scope is not None:
-            action = parse_scope(username, scope)
+        if scopes is not None:
+            actions = parse_scopes(username, scopes)
             user = self.user_service.find_by_username(username)
-            repo = self.repo_service.find_by_canonical_name(action.repo_canonical_name)
 
-            for operation in action.operations:
+            for action in actions:
+                repo = self.repo_service.find_by_canonical_name(action.repo_canonical_name)
 
-                # Case 1 - User requested push operation on the repo.
+                for operation in action.operations:
 
-                if operation == RegistryActionOperation.push:
-                    # This will cover all the neccessary cases:
-                    #  - repo doesn't exist
-                    #  - user doesn't exist
-                    #  - user doesn't have access
-                    #  - etc.
+                    # Case 1 - User requested push operation on the repo.
 
-                    can_write = self.access_control_service.has_write_access(user.id, repo.id)
-                    if not can_write:
-                        raise HTTPException(status_code=401, detail=f"User {user.username} cannot push to repo {repo.canonical_name}")      
-                    
-                # Case 2 - User requested pull operation on the repo.
+                    if operation == RegistryActionOperation.push:
+                        # This will cover all the neccessary cases:
+                        #  - repo doesn't exist
+                        #  - user doesn't exist
+                        #  - user doesn't have access
+                        #  - etc.
 
-                elif operation == RegistryActionOperation.pull:
-                    can_read = self.access_control_service.has_read_access(user.id, repo.id)
-                    if not can_read:
-                        raise HTTPException(status_code=401, detail=f"User {user.username} cannot pull from repo {repo.canonical_name}")
-                    
-                # Case 3 - Unknown operation.
+                        can_write = self.access_control_service.has_write_access(user.id, repo.id)
+                        if not can_write:
+                            raise HTTPException(status_code=401, detail=f"User {user.username} cannot push to repo {repo.canonical_name}")      
+                        
+                    # Case 2 - User requested pull operation on the repo.
 
-                else:
-                    raise HTTPException(status_code=400, detail=f"Unknown operations {action.operations}")
-            
+                    elif operation == RegistryActionOperation.pull:
+                        can_read = self.access_control_service.has_read_access(user.id, repo.id)
+                        if not can_read:
+                            raise HTTPException(status_code=401, detail=f"User {user.username} cannot pull from repo {repo.canonical_name}")
+                        
+                    # Case 3 - Unknown operation.
+
+                    else:
+                        raise HTTPException(status_code=400, detail=f"Unknown operation {operation}")
+                
         # Create the JWT.
-            
-        jwt = build_jwt_for_docker_registry(username, service, scope)
+        jwt = build_jwt_for_docker_registry(username, service, scopes)
         return {"token": jwt}
     
 def get_registry_service(session: Session = Depends(get_database)) -> RegistryService:

--- a/server/app/api/registry/registry_utils.py
+++ b/server/app/api/registry/registry_utils.py
@@ -5,6 +5,7 @@ import uuid
 
 import jwt
 
+from typing import List, Literal
 from app.api.registry.registry_dto import RegistryAction, RegistryActionOperation
 
 SECRET_KEY = ""
@@ -50,28 +51,32 @@ def decode_auth_header(auth_token):
     return username, password
 
 
-def parse_scope(username: str, scope: str) -> RegistryAction:
+def parse_scopes(username: str, scopes: List[str]) -> List[RegistryAction]:
     """
-    Parse scope from Docker Registry request.
+    Parse scopes from Docker Registry request.
 
     `username` is the username of the user making the request.
 
-    `scope` is the scope of resource access built into the JWT, or `None` if the
-    Docker Registry request is just a login operation. For example:
+    `scopes` are the list of scopes of resource access built into the JWT, or `None` if the
+    Docker Registry request is just a login operation. For example, a single scope:
     `repository:nginx:push,pull` means that the user wants access to push and
     pull to the official `nginx` repository.
     """
+    actions = []
 
-    scope_parts = scope.split(':')   
-    if scope_parts[0] != 'repository':
-        raise Exception(f"Unexpected scope type '{scope_parts[0]}'. Expecting 'repository'")
-    repository = scope_parts[1]
-    operations = [RegistryActionOperation(o) for o in scope_parts[2].split(',')]
+    for scope in scopes:
+        scope_parts = scope.split(':')   
+        if scope_parts[0] != 'repository':
+            raise Exception(f"Unexpected scope type '{scope_parts[0]}'. Expecting 'repository'")
+        repository = scope_parts[1]
+        operations = [RegistryActionOperation(o) for o in scope_parts[2].split(',')]
+        action = RegistryAction(username=username, repo_canonical_name=repository, operations=operations)
+        actions.append(action)
 
-    return RegistryAction(username=username, repo_canonical_name=repository, operations=operations)
+    return actions
 
 
-def build_jwt_for_docker_registry(username: str, service: str, scope: str) -> str:
+def build_jwt_for_docker_registry(username: str, service: str, scopes: List[str]) -> str:
     """
     Create a JWT as required by Docker Registry.
 
@@ -83,14 +88,14 @@ def build_jwt_for_docker_registry(username: str, service: str, scope: str) -> st
     this is the audience for the JWT. This value should be extracted from the
     HTTP request issued by Docker Registry.
 
-    `scope` is the scope of resource access built into the JWT, or `None` if the
-    Docker Registry request is just a login operation. For example:
+    `scopes` are the list of scopes of resource access built into the JWT, or `None` if the
+    Docker Registry request is just a login operation. For example, a single scope:
     `repository:nginx:push,pull` means that the user wants access to push and
     pull to the official `nginx` repository.
 
     ---
 
-    Returns a string representaiton of the encoded JWT.
+    Returns a string representation of the encoded JWT.
     """
     now = datetime.datetime.now()
 
@@ -108,14 +113,16 @@ def build_jwt_for_docker_registry(username: str, service: str, scope: str) -> st
         'x5c': [CERT_DER_B64] 
     }
 
-    if scope is not None:
-        scope_parts = scope.split(':')   
-        token_payload['access'] = [
-            {
-                'type': 'repository',
-                'name': scope_parts[1],
-                'actions': scope_parts[2].split(',')
-            }
-        ]
+    if scopes is not None:
+        token_payload['access'] = []
+        for scope in scopes:
+            scope_parts = scope.split(':')   
+            token_payload['access'].append(
+                {
+                    'type': scope_parts[0],
+                    'name': scope_parts[1],
+                    'actions': scope_parts[2].split(',')
+                }
+            )
 
     return jwt.encode(token_payload, SECRET_KEY, algorithm='RS256', headers=token_headers)    

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -47,6 +47,7 @@ def test_handle_registry_request_push(registry_service: RegistryService, mock_jw
     registry_service.user_service.exists_with_credentials.assert_called_once_with(username, password)
     registry_service.repo_service.find_by_canonical_name.assert_called_once_with("test/repo")
     registry_service.access_control_service.has_write_access.assert_called_once_with(1, 1)
+    registry_service.access_control_service.has_read_access.assert_called_once_with(1, 1)
 
 def test_handle_registry_request_invalid_credentials(registry_service: RegistryService):
     registry_service.user_service.exists_with_credentials.return_value = False
@@ -114,6 +115,7 @@ def test_handle_registry_request_unknown_operation(registry_service: RegistrySer
 def test_handle_registry_request_jwt_generation(registry_service: RegistryService, mock_jwt_encode):
     registry_service.user_service.exists_with_credentials.return_value = True
     registry_service.user_service.find_by_username.return_value = MagicMock(id=1, username="testuser")
+    registry_service.repo_service.find_by_canonical_name.return_value = MagicMock(id=1, canonical_name="test/repo")
 
     scope = "repository:test/repo:push,pull"
     username = "testuser"
@@ -124,6 +126,8 @@ def test_handle_registry_request_jwt_generation(registry_service: RegistryServic
     
     assert response["token"] == "mocked.jwt.token"
     registry_service.user_service.exists_with_credentials.assert_called_once_with(username, password)
+    registry_service.access_control_service.has_write_access.assert_called_once_with(1, 1)
+    registry_service.access_control_service.has_read_access.assert_called_once_with(1, 1)
 
 # -----------------------------------
 # Util functions

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -1,13 +1,13 @@
 import jwt
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from fastapi import HTTPException
 from app.api.registry.registry_service import RegistryService
 from app.api.registry.registry_dto import RegistryActionOperation
 from app.api.user.user_service import UserService
 from app.api.repo.repo_service import RepositoryService
 from app.api.access_control.access_control_service import AccessControlService
-from app.api.registry.registry_utils import build_jwt_for_docker_registry, parse_scope
+from app.api.registry.registry_utils import build_jwt_for_docker_registry, parse_scopes
 
 @pytest.fixture
 def registry_service() -> RegistryService:
@@ -36,12 +36,12 @@ def test_handle_registry_request_push(registry_service: RegistryService, mock_jw
     registry_service.repo_service.find_by_canonical_name.return_value = MagicMock(id=1, canonical_name="test/repo")
     registry_service.access_control_service.has_write_access.return_value = True
 
-    scope = "repository:test/repo:push,pull"
+    scopes = ["repository:test/repo:push,pull"]
     username = "testuser"
     password = "password"
     service = "docker-registry"
 
-    response = registry_service.handle_registry_request(username, password, scope, service)
+    response = registry_service.handle_registry_request(username, password, scopes, service)
     
     assert response["token"] == "mocked.jwt.token"
     registry_service.user_service.exists_with_credentials.assert_called_once_with(username, password)
@@ -49,16 +49,46 @@ def test_handle_registry_request_push(registry_service: RegistryService, mock_jw
     registry_service.access_control_service.has_write_access.assert_called_once_with(1, 1)
     registry_service.access_control_service.has_read_access.assert_called_once_with(1, 1)
 
+def test_handle_registry_request_push_with_mount(registry_service: RegistryService, mock_jwt_encode):
+    registry_service.user_service.exists_with_credentials.return_value = True
+    registry_service.user_service.find_by_username.return_value = MagicMock(id=1, username="testuser")
+    registry_service.access_control_service.has_write_access.return_value = True
+    registry_service.access_control_service.has_read_access.return_value = True
+
+    def find_repo_by_name(name):
+        if name == "test/repo1":
+            return MagicMock(id=1, canonical_name="test/repo1")
+        elif name == "test/repo2":
+            return MagicMock(id=2, canonical_name="test/repo2")
+        return None
+
+    registry_service.repo_service.find_by_canonical_name.side_effect = find_repo_by_name
+
+    scopes = ["repository:test/repo1:pull", "repository:test/repo2:pull", "repository:test/repo2:pull,push"]
+    username = "testuser"
+    password = "password"
+    service = "docker-registry"
+
+    response = registry_service.handle_registry_request(username, password, scopes, service)
+    
+    assert response["token"] == "mocked.jwt.token"
+    registry_service.user_service.exists_with_credentials.assert_called_once_with(username, password)
+    expected_calls = [call(1, 1), call(1, 2), call(1, 2)]
+    assert registry_service.access_control_service.has_read_access.call_args_list == expected_calls
+    registry_service.access_control_service.has_write_access.assert_called_once_with(1, 2)
+    expected_calls = [call("test/repo1"), call("test/repo2"), call("test/repo2")]
+    assert registry_service.repo_service.find_by_canonical_name.call_args_list == expected_calls
+
 def test_handle_registry_request_invalid_credentials(registry_service: RegistryService):
     registry_service.user_service.exists_with_credentials.return_value = False
 
-    scope = "repository:test/repo:push,pull"
+    scopes = ["repository:test/repo:push,pull"]
     username = "invaliduser"
     password = "wrongpassword"
     service = "docker-registry"
 
     with pytest.raises(HTTPException) as excinfo:
-        registry_service.handle_registry_request(username, password, scope, service)
+        registry_service.handle_registry_request(username, password, scopes, service)
     
     assert excinfo.value.status_code == 401
     assert "Invalid username or password" in str(excinfo.value.detail)
@@ -69,12 +99,12 @@ def test_handle_registry_request_pull(registry_service: RegistryService, mock_jw
     registry_service.repo_service.find_by_canonical_name.return_value = MagicMock(id=1, canonical_name="test/repo")
     registry_service.access_control_service.has_read_access.return_value = True
 
-    scope = "repository:test/repo:pull"
+    scopes = ["repository:test/repo:pull"]
     username = "testuser"
     password = "password"
     service = "docker-registry"
 
-    response = registry_service.handle_registry_request(username, password, scope, service)
+    response = registry_service.handle_registry_request(username, password, scopes, service)
     
     assert response["token"] == "mocked.jwt.token"
     registry_service.user_service.exists_with_credentials.assert_called_once_with(username, password)
@@ -87,29 +117,70 @@ def test_handle_registry_request_no_push_access(registry_service: RegistryServic
     registry_service.repo_service.find_by_canonical_name.return_value = MagicMock(id=1, canonical_name="test/repo")
     registry_service.access_control_service.has_write_access.return_value = False
 
-    scope = "repository:test/repo:push"
+    scopes = ["repository:test/repo:push"]
     username = "testuser"
     password = "password"
     service = "docker-registry"
 
     with pytest.raises(HTTPException) as excinfo:
-        registry_service.handle_registry_request(username, password, scope, service)
+        registry_service.handle_registry_request(username, password, scopes, service)
 
     assert excinfo.value.status_code == 401
     assert "User testuser cannot push to repo test/repo" in str(excinfo.value.detail)
+
+def test_handle_registry_request_push_with_mount_no_pull_access(registry_service: RegistryService, mock_jwt_encode):
+    registry_service.user_service.exists_with_credentials.return_value = True
+    registry_service.user_service.find_by_username.return_value = MagicMock(id=1, username="testuser")
+    registry_service.access_control_service.has_write_access.return_value = True
+
+    def check_read_access(user_id, repo_id):
+        if (user_id, repo_id) == (1, 1):
+            return False
+        elif (user_id, repo_id) == (1, 2):
+            return True
+        return None
+
+    registry_service.access_control_service.has_read_access.side_effect = check_read_access
+
+    def find_repo_by_name(name):
+        if name == "test/repo1":
+            return MagicMock(id=1, canonical_name="test/repo1")
+        elif name == "test/repo2":
+            return MagicMock(id=2, canonical_name="test/repo2")
+        return None
+
+    registry_service.repo_service.find_by_canonical_name.side_effect = find_repo_by_name
+
+    scopes = ["repository:test/repo2:pull", "repository:test/repo2:pull,push", "repository:test/repo1:pull"]
+    username = "testuser"
+    password = "password"
+    service = "docker-registry"
+
+    with pytest.raises(HTTPException) as excinfo:
+        registry_service.handle_registry_request(username, password, scopes, service)
+    
+    assert excinfo.value.status_code == 401
+    assert "User testuser cannot pull from repo test/repo1" in str(excinfo.value.detail)
+
+    registry_service.user_service.exists_with_credentials.assert_called_once_with(username, password)
+    expected_calls = [call(1, 2), call(1, 2), call(1, 1)]
+    assert registry_service.access_control_service.has_read_access.call_args_list == expected_calls
+    registry_service.access_control_service.has_write_access.assert_called_once_with(1, 2)
+    expected_calls = [call("test/repo2"), call("test/repo2"), call("test/repo1")]
+    assert registry_service.repo_service.find_by_canonical_name.call_args_list == expected_calls
 
 def test_handle_registry_request_unknown_operation(registry_service: RegistryService):
     registry_service.user_service.exists_with_credentials.return_value = True
     registry_service.user_service.find_by_username.return_value = MagicMock(id=1, username="testuser")
     registry_service.repo_service.find_by_canonical_name.return_value = MagicMock(id=1, canonical_name="test/repo")
 
-    scope = "repository:test/repo:delete"
+    scopes = ["repository:test/repo:delete"]
     username = "testuser"
     password = "password"
     service = "docker-registry"
 
     with pytest.raises(ValueError) as ex:
-        registry_service.handle_registry_request(username, password, scope, service)
+        registry_service.handle_registry_request(username, password, scopes, service)
     assert "delete" in str(ex)
 
 def test_handle_registry_request_jwt_generation(registry_service: RegistryService, mock_jwt_encode):
@@ -117,46 +188,53 @@ def test_handle_registry_request_jwt_generation(registry_service: RegistryServic
     registry_service.user_service.find_by_username.return_value = MagicMock(id=1, username="testuser")
     registry_service.repo_service.find_by_canonical_name.return_value = MagicMock(id=1, canonical_name="test/repo")
 
-    scope = "repository:test/repo:push,pull"
+
+    scopes = ["repository:test/repo:push,pull"]
     username = "testuser"
     password = "password"
     service = "docker-registry"
 
-    response = registry_service.handle_registry_request(username, password, scope, service)
+    response = registry_service.handle_registry_request(username, password, scopes, service)
     
     assert response["token"] == "mocked.jwt.token"
     registry_service.user_service.exists_with_credentials.assert_called_once_with(username, password)
     registry_service.access_control_service.has_write_access.assert_called_once_with(1, 1)
     registry_service.access_control_service.has_read_access.assert_called_once_with(1, 1)
-
+    
 # -----------------------------------
 # Util functions
 # -----------------------------------
 
-def test_parse_scope_valid_input():
-    scope = "repository:test/repo:push,pull"
+def test_parse_scopes_valid_input():
+    scopes = ["repository:test/repo1:push,pull", "repository:test/repo2:pull"]
     username = "testuser"
 
-    result = parse_scope(username, scope)
+    actions = parse_scopes(username, scopes)
 
-    assert result.username == "testuser"
-    assert result.repo_canonical_name == "test/repo"
-    assert result.operations == [RegistryActionOperation.push, RegistryActionOperation.pull]
+    action = actions[0]
+    assert action.username == "testuser"
+    assert action.repo_canonical_name == "test/repo1"
+    assert action.operations == [RegistryActionOperation.push, RegistryActionOperation.pull]
 
-def test_parse_scope_invalid_scope():
-    scope = "repository:test/repo:push,delete"
+    action = actions[1]
+    assert action.username == "testuser"
+    assert action.repo_canonical_name == "test/repo2"
+    assert action.operations == [RegistryActionOperation.pull]
+
+def test_parse_scopes_invalid_scope():
+    scopes = ["repository:test/repo:push,delete"]
     username = "testuser"
 
     with pytest.raises(ValueError) as ex:
-        parse_scope(username, scope)
+        parse_scopes(username, scopes)
     assert "delete" in str(ex)
 
 def test_build_jwt_for_docker_registry_with_scope(mock_jwt_encode):
     username = "testuser"
     service = "docker-registry"
-    scope = "repository:test/repo:push,pull"
+    scopes = ["repository:test/repo:push,pull", "repository:test/repo:pull"]
 
-    jwt_token = build_jwt_for_docker_registry(username, service, scope)
+    jwt_token = build_jwt_for_docker_registry(username, service, scopes)
 
     assert isinstance(jwt_token, str)
     assert len(jwt_token) > 0


### PR DESCRIPTION
Closes #41.

Improved scope parsing resolved the main issue.

Additionally, I discovered that authorization checks were incorrectly skipping some operations—only the first `RegistryActionOperation` was being checked.

Tests were failing due to an issue that is already resolved in [#9b4abb6](https://github.com/magley/mocker-hub/commit/9b4abb6dc5532fbc1fa85d99f5d92d578450f799).