### PR TITLE
Feature delete repository

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,4 +33,5 @@ jobs:
       # But we must be careful about `depends-on` in `compose.yaml`.
       # https://stackoverflow.com/a/76049965
       run: |
+        sudo docker compose build
         sudo docker compose up --build backend --abort-on-container-exit --exit-code-from backend

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -56,6 +56,10 @@ export interface ToggleStarRepoDTO extends RepoDTO {
     starred: boolean,
 }
 
+export interface DeleteRepoResponseDTO {
+    message: string
+}
+
 export class RepositoryService {
     static BadgeToHumanText(badge: RepositoryBadge): string {
         switch (badge) {
@@ -117,5 +121,9 @@ export class RepositoryService {
 
     static async ToggleRepositoryStar(repoId: number) : Promise<AxiosResponse<ToggleStarRepoDTO>> {
         return await axiosInstance.put(`/repositories/star/${repoId}`)
+    }
+
+    static async DeleteRepo(repoId: number) : Promise<AxiosResponse<DeleteRepoResponseDTO>> {
+        return await axiosInstance.delete(`/registry/repository/${repoId}`)
     }
 }

--- a/client/src/components/RepoSettings.tsx
+++ b/client/src/components/RepoSettings.tsx
@@ -37,6 +37,18 @@ export const RepoSettings: React.FC<{ isActive: boolean, repo: RepoExtDTO, setRe
         });
     }
 
+    const handleDeleteRepo = async () => {
+            RepositoryService.DeleteRepo(props.repo.id)
+                .then((res) => {
+                    addToast(res.data.message, ToastType.success);
+                })
+                .catch((err: AxiosError) => {
+                    const data = (err.response?.data ?? {}) as any;
+                    const msg = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    addToast(msg, ToastType.error);
+                })
+        };
+
     return (
         <div className="tab-pane fade show active" id="settings">
             <Card className="mt-4">
@@ -54,6 +66,17 @@ export const RepoSettings: React.FC<{ isActive: boolean, repo: RepoExtDTO, setRe
                     <Button variant="outline-primary" onClick={changeVisibility}>
                         {props.repo.public ? 'Make private' : 'Make public'}
                     </Button>
+                </Card.Body>
+            </Card>
+        
+            <Card className="mt-4">
+                <Card.Body>
+                    <Card.Title className="d-flex align-items-center">
+                        <h5 className="mb-0">Delete repository</h5>
+                    </Card.Title>
+                    {error && <Alert variant="danger">{error}</Alert>}
+                    <p className="text-muted mt-3"> Deleting a repository will destroy all images stored within it. This action cannot be undone. </p>
+                    <Button variant="outline-danger" onClick={handleDeleteRepo}>Delete repository</Button>
                 </Card.Body>
             </Card>
         </div>

--- a/client/src/components/RepoSettings.tsx
+++ b/client/src/components/RepoSettings.tsx
@@ -38,16 +38,16 @@ export const RepoSettings: React.FC<{ isActive: boolean, repo: RepoExtDTO, setRe
     }
 
     const handleDeleteRepo = async () => {
-            RepositoryService.DeleteRepo(props.repo.id)
-                .then((res) => {
-                    addToast(res.data.message, ToastType.success);
-                })
-                .catch((err: AxiosError) => {
-                    const data = (err.response?.data ?? {}) as any;
-                    const msg = typeof data.detail === 'string' ? data.detail : data.detail?.message;
-                    addToast(msg, ToastType.error);
-                })
-        };
+        RepositoryService.DeleteRepo(props.repo.id)
+            .then((res) => {
+                addToast(res.data.message, ToastType.success);
+            })
+            .catch((err: AxiosError) => {
+                const data = (err.response?.data ?? {}) as any;
+                const msg = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                addToast(msg, ToastType.error);
+            })
+    };
 
     return (
         <div className="tab-pane fade show active" id="settings">

--- a/compose.yaml
+++ b/compose.yaml
@@ -87,6 +87,11 @@ services:
     restart: always
     ports:
       - '6888:6379'
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     # volumes: 
     #   - cache:/data
     

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,19 @@
+x-common-variables: &common-variables
+  PYTHONUNBUFFERED: 1
+  POSTGRES_USER: postgres
+  POSTGRES_DATABASE: postgres
+  POSTGRES_PASSWORD: admin
+  REDIS_HOST: cache
+  REDIS_PORT: 6379
+  SUPERADMIN_PASSWORD: admin123 #
+  JWT_SECRET: secret
+  JWT_ALGORITHM: HS256
+  ELASTICSEARCH_HOST: elasticsearch #
+  ELASTICSEARCH_PORT: 9200 #
+  DISTRIBUTION_HOST: distribution
+  DISTRIBUTION_PORT: 5000
+  PEM_CERT_PATH: /code/certs/cert.pem
+
 services:
   backend:
     build: ./server
@@ -13,21 +29,9 @@ services:
       - elasticsearch
       - distribution
       - log_collector
+      - worker
     environment:
-      PYTHONUNBUFFERED: 1
-      POSTGRES_USER: postgres
-      POSTGRES_DATABASE: postgres
-      POSTGRES_PASSWORD: admin
-      REDIS_HOST: cache
-      REDIS_PORT: 6379
-      SUPERADMIN_PASSWORD: admin123
-      JWT_SECRET: secret
-      JWT_ALGORITHM: HS256
-      ELASTICSEARCH_HOST: elasticsearch
-      ELASTICSEARCH_PORT: 9200
-      DISTRIBUTION_HOST: distribution
-      DISTRIBUTION_PORT: 5000
-      PEM_CERT_PATH: /code/certs/cert.pem
+      <<: *common-variables
 
       # To run tests, do `RUN_TESTS=true docker compose up`.
       # However, I've been having issues with this on WSL,
@@ -96,13 +100,23 @@ services:
     #   - cache:/data
     
   worker:
-    build: ./worker
+    image: magley/mocker-hub-backend:latest
+    restart: always
     environment:
       REDIS_SCHEME: redis 
-      REDIS_HOST: cache
-      REDIS_PORT: 6379
+      PYTHONPATH: /code
+      <<: *common-variables
+    entrypoint: []
+    command: ["python", "-m", "app.api.config.worker"]
     depends_on:
+      - db
       - cache
+      - distribution
+    volumes:
+      - backend_cfg:/code/volume-server-cfg/
+      - ./images:/code/images
+      - ./distribution/certs:/code/certs
+      - ./logs:/code/logs
 
   rq_dashboard:
     image: eoranged/rq-dashboard:v0.6.3

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,11 +5,11 @@ x-common-variables: &common-variables
   POSTGRES_PASSWORD: admin
   REDIS_HOST: cache
   REDIS_PORT: 6379
-  SUPERADMIN_PASSWORD: admin123 #
+  SUPERADMIN_PASSWORD: admin123
   JWT_SECRET: secret
   JWT_ALGORITHM: HS256
-  ELASTICSEARCH_HOST: elasticsearch #
-  ELASTICSEARCH_PORT: 9200 #
+  ELASTICSEARCH_HOST: elasticsearch
+  ELASTICSEARCH_PORT: 9200
   DISTRIBUTION_HOST: distribution
   DISTRIBUTION_PORT: 5000
   PEM_CERT_PATH: /code/certs/cert.pem

--- a/compose.yaml
+++ b/compose.yaml
@@ -88,7 +88,17 @@ services:
     ports:
       - '6888:6379'
     # volumes: 
-      # - cache:/data
+    #   - cache:/data
+    
+  worker:
+    build: ./worker
+    environment:
+      REDIS_SCHEME: redis 
+      REDIS_HOST: cache
+      REDIS_PORT: 6379
+    depends_on:
+      - cache
+
 
   distribution:
     image: "registry:2" 

--- a/compose.yaml
+++ b/compose.yaml
@@ -119,7 +119,7 @@ services:
       - ./logs:/code/logs
 
   rq_dashboard:
-    image: eoranged/rq-dashboard:v0.6.3
+    image: cjlapao/rq-dashboard:0.8.3
     ports:
       - "9181:9181"
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -99,6 +99,14 @@ services:
     depends_on:
       - cache
 
+  rq_dashboard:
+    image: eoranged/rq-dashboard:v0.6.3
+    ports:
+      - "9181:9181"
+    environment:
+      RQ_DASHBOARD_REDIS_URL: redis://cache:6379
+    depends_on:
+      - cache
 
   distribution:
     image: "registry:2" 

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,7 +27,7 @@ services:
       - cache
       # - nginx
       - elasticsearch
-      - distribution
+      # - distribution
       - log_collector
       - worker
     environment:
@@ -109,9 +109,7 @@ services:
     entrypoint: []
     command: ["python", "-m", "app.api.config.worker"]
     depends_on:
-      - db
       - cache
-      - distribution
     volumes:
       - backend_cfg:/code/volume-server-cfg/
       - ./images:/code/images
@@ -131,6 +129,8 @@ services:
     image: "registry:2" 
     ports:
       - "5000:5000"
+    depends_on:
+      - backend  # Certs must be unzipped first.
     volumes:
       - "./distribution/config.yaml:/etc/docker/registry/config.yml"
       - "./distribution/certs:/mnt/local/certs"

--- a/server/app/api/access_control/access_control_service.py
+++ b/server/app/api/access_control/access_control_service.py
@@ -166,7 +166,8 @@ class AccessControlService:
     # - Be the owner of the repository.
     # - Belong to a team that has either 'admin' or 'read_write' permissions.
     # The same conditions apply to the `has_write_access` method.    
-    def has_delete_tag_access(self, user_id: int | None, repo_id: int) -> bool:
+    # This method handles permission checks for both repository and tag deletions.
+    def has_delete_access(self, user_id: int | None, repo_id: int) -> bool:
         return self.has_write_access(user_id, repo_id)    
 
 def get_access_control_service(session: Session = Depends(get_database)) -> AccessControlService:

--- a/server/app/api/config/initialize.py
+++ b/server/app/api/config/initialize.py
@@ -2,6 +2,7 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from httpx import AsyncClient
+from app.api.jobs.jobs_client import JobsClient
 from sqlmodel import SQLModel, select
 from app.api.config.database import engine, get_database
 from app.api.user.user_model import User, UserRole
@@ -34,6 +35,11 @@ def init_registry_client():
     port = os.environ["DISTRIBUTION_PORT"]
     cert = os.environ["PEM_CERT_PATH"]
     return RegistryClient(AsyncClient(verify=cert), host, port, True)
+
+def init_jobs_client():
+    host = os.environ["REDIS_HOST"]
+    port = os.environ["REDIS_PORT"]
+    return JobsClient(host, port)
 
 def init_superadmin():
     session = next(get_database())

--- a/server/app/api/config/worker.py
+++ b/server/app/api/config/worker.py
@@ -8,6 +8,6 @@ port = os.environ["REDIS_PORT"]
 connection = Redis.from_url(f"{scheme}://{host}:{port}")
 
 if __name__ == '__main__':
-    default_queue = [Queue(name, connection=connection) for name in ['default']]
+    default_queue = [Queue(name, connection=connection) for name in ['delete_tag']]
     worker = Worker(queues=default_queue, connection=connection)
     worker.work()

--- a/server/app/api/config/worker.py
+++ b/server/app/api/config/worker.py
@@ -9,5 +9,5 @@ connection = Redis.from_url(f"{scheme}://{host}:{port}")
 
 if __name__ == '__main__':
     default_queue = [Queue(name, connection=connection) for name in ['delete_tag']]
-    worker = Worker(queues=default_queue, connection=connection)
-    worker.work()
+    worker = Worker(queues=default_queue, connection=connection, job_monitoring_interval=2)
+    worker.work(with_scheduler=True)

--- a/server/app/api/jobs/jobs_client.py
+++ b/server/app/api/jobs/jobs_client.py
@@ -1,0 +1,17 @@
+from redis import Redis
+from fastapi import Request
+from rq import Queue
+
+class JobsClient:
+    
+    def __init__(self, host, port):
+        self.connection: Redis = Redis(host=host, port=port)
+
+    def create(self, name: str) -> Queue:
+        return Queue(name, connection=self.connection)
+
+    def get(self, name: str) -> Queue:
+        return self.create(name)
+    
+def get_jobs_client(request: Request = Request) -> JobsClient:
+    return request.app.jobs_client

--- a/server/app/api/jobs/jobs_service.py
+++ b/server/app/api/jobs/jobs_service.py
@@ -35,7 +35,7 @@ def delete_tag_job(username:str, repo_id: int, tag_name: str):
             registry_service.event_service.log(
                 EventLevel.Error, 
                 (
-                    f"Tag '{tag.name}' is not deleted (retries_left={retries_left}, job_id={job_id}, queue={origin}). " 
+                    f"Tag '{tag.name}' is not deleted (job_id={job_id}, retries_left={retries_left}, queue={origin}). " 
                     f"ADMIN: For an immediate response, check both the queue dashboard and the log trace."
                 )
             )

--- a/server/app/api/jobs/jobs_service.py
+++ b/server/app/api/jobs/jobs_service.py
@@ -4,6 +4,7 @@ from rq import get_current_job
 from app.api.config.database import get_database
 from app.api.config.initialize import init_registry_client
 from app.api.events.event_model import EventLevel
+from app.api.config.exception_handler import NotFoundException, NotInRelationshipException
 
 class JobsService:
 
@@ -39,14 +40,14 @@ class JobsService:
         try:
             repo = registry_service.repo_service.find_by_id(repo_id)
             tag = registry_service.tag_service.find_by_name_and_repo_id(tag_name, repo_id)
-
-        except Exception:
-            registry_service.event_service.log(EventLevel.Info, f"Tag '{tag_name}' has already been deleted by another job.")
-            return
-
-        try:
             response = loop.run_until_complete(registry_service.delete_tag(client, username, repo, tag))
             registry_service.event_service.log(EventLevel.Info, response.message)
+
+        except NotFoundException:
+            registry_service.event_service.log(EventLevel.Info, f"Repository with identifier '{repo_id}' has already been deleted by another job.")
+
+        except NotInRelationshipException:
+            registry_service.event_service.log(EventLevel.Info, f"Tag '{tag_name}' has already been deleted by another job.")
 
         except Exception:
             job_info = self._get_current_job_metadata()

--- a/server/app/api/jobs/jobs_service.py
+++ b/server/app/api/jobs/jobs_service.py
@@ -1,41 +1,60 @@
 import asyncio
-
+from sqlmodel import Session
 from rq import get_current_job
 from app.api.config.database import get_database
 from app.api.config.initialize import init_registry_client
 from app.api.events.event_model import EventLevel
 
-def delete_tag_job(username:str, repo_id: int, tag_name: str):
-    from app.api.registry.registry_service import RegistryService
-    
-    client = init_registry_client()
+class JobsService:
 
-    with next(get_database()) as session:
+    # NOTE: Other services should not be added
+    # as they will create circular dependencies,
+    # and jobs are run in function scope.
+    # All required services should be defined
+    # within the function itself.
+
+    def _get_session(self) -> Session:
+        return next(get_database())
+
+    def _get_event_loop(self) -> asyncio.AbstractEventLoop:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+    def _get_current_job_metadata(self) -> dict:
+        job = get_current_job()
+        return {
+            "id": job.id if job else "unknown",
+            "origin": job.origin if job else "unknown",
+            "retries_left": job.retries_left if job else "unknown"
+        }
+
+    def delete_tag_job(self, username:str, repo_id: int, tag_name: str):
+        from app.api.registry.registry_service import RegistryService
+        session = self._get_session()
+        loop = self._get_event_loop()
+        client = init_registry_client()
         registry_service = RegistryService(session)
+
         try:
             repo = registry_service.repo_service.find_by_id(repo_id)
             tag = registry_service.tag_service.find_by_name_and_repo_id(tag_name, repo_id)
+
         except Exception:
             registry_service.event_service.log(EventLevel.Info, f"Tag '{tag_name}' has already been deleted by another job.")
             return
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        
         try:
             response = loop.run_until_complete(registry_service.delete_tag(client, username, repo, tag))
             registry_service.event_service.log(EventLevel.Info, response.message)
 
         except Exception:
-            job = get_current_job()
-            job_id = job.id if job else "unknown"
-            origin = job.origin if job else "unknown"
-            retries_left = job.retries_left if job else "unknown"
+            job_info = self._get_current_job_metadata()
 
             registry_service.event_service.log(
                 EventLevel.Error, 
                 (
-                    f"Tag '{tag.name}' is not deleted (job_id={job_id}, retries_left={retries_left}, queue={origin}). " 
+                    f"Tag '{tag.name}' is not deleted (job_id={job_info['id']}, retries_left={job_info['retries_left']}, queue={job_info['origin']}). " 
                     f"ADMIN: For an immediate response, check both the queue dashboard and the log trace."
                 )
             )
@@ -43,3 +62,7 @@ def delete_tag_job(username:str, repo_id: int, tag_name: str):
         
         finally:
             loop.close()
+            session.close()
+
+def get_team_service() -> JobsService:
+    return JobsService()

--- a/server/app/api/jobs/jobs_service.py
+++ b/server/app/api/jobs/jobs_service.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from rq import get_current_job
+from app.api.config.database import get_database
+from app.api.config.initialize import init_registry_client
+from app.api.events.event_model import EventLevel
+
+def delete_tag_job(username:str, repo_id: int, tag_name: str):
+    from app.api.registry.registry_service import RegistryService
+    
+    client = init_registry_client()
+
+    with next(get_database()) as session:
+        registry_service = RegistryService(session)
+        try:
+            repo = registry_service.repo_service.find_by_id(repo_id)
+            tag = registry_service.tag_service.find_by_name_and_repo_id(tag_name, repo_id)
+        except Exception:
+            registry_service.event_service.log(EventLevel.Info, f"Tag '{tag_name}' has already been deleted by another job.")
+            return
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        
+        try:
+            response = loop.run_until_complete(registry_service.delete_tag(client, username, repo, tag))
+            registry_service.event_service.log(EventLevel.Info, response.message)
+
+        except Exception:
+            job = get_current_job()
+            job_id = job.id if job else "unknown"
+            origin = job.origin if job else "unknown"
+            retries_left = job.retries_left if job else "unknown"
+
+            registry_service.event_service.log(
+                EventLevel.Error, 
+                (
+                    f"Tag '{tag.name}' is not deleted (retries_left={retries_left}, job_id={job_id}, queue={origin}). " 
+                    f"ADMIN: For an immediate response, check both the queue dashboard and the log trace."
+                )
+            )
+            raise
+        
+        finally:
+            loop.close()

--- a/server/app/api/main.py
+++ b/server/app/api/main.py
@@ -1,10 +1,8 @@
 import asyncio
-import os
 from fastapi import APIRouter, FastAPI
 from contextlib import asynccontextmanager
 
-from httpx import AsyncClient
-from app.api.config.initialize import init_create_tables, configure_cors, init_dummy_data, init_registry_client, init_superadmin
+from app.api.config.initialize import init_create_tables, configure_cors, init_dummy_data, init_jobs_client, init_registry_client, init_superadmin
 from app.api.config.exception_handler import register_exception_handler
 import app.api.events
 import app.api.events.event_controller
@@ -40,6 +38,7 @@ async def lifespan(app: FastAPI):
     init_create_tables()
     init_cache()
     init_superadmin()
+    app.jobs_client = init_jobs_client()
     app.registry_client = init_registry_client()
     asyncio.create_task(try_to_init_elasticsearch())
     yield

--- a/server/app/api/registry/registry_controller.py
+++ b/server/app/api/registry/registry_controller.py
@@ -7,7 +7,7 @@ from app.api.config.logutil import LOGGER
 from app.api.user.user_model import UserRole
 from app.api.config.auth import JWTDep, get_id_from_jwt, get_username_from_jwt, pre_authorize
 from app.api.tags.tag_service import TagService, get_tag_service
-from app.api.registry.registry_dto import DeleteTagDTO, DeleteTagResponseDTO
+from app.api.registry.registry_dto import DeleteTagDTO, DeleteResponseDTO
 from app.api.repo.repo_service import RepositoryService, get_repo_service
 from app.api.access_control.access_control_service import AccessControlService, get_access_control_service
 from app.api.config.exception_handler import AccessDeniedException
@@ -52,7 +52,7 @@ def registry_notification_endpoint(data: dict, registry_service: RegistryService
 
     return {}
 
-@external_router.delete("/tag", status_code=200, summary="Delete a tag by its name", response_model=DeleteTagResponseDTO)
+@external_router.delete("/tag", status_code=200, summary="Delete a tag by its name", response_model=DeleteResponseDTO)
 @pre_authorize([UserRole.user, UserRole.admin])                             
 async def delete_tag_endpoint(
     jwt: JWTDep,
@@ -68,7 +68,7 @@ async def delete_tag_endpoint(
     repo = repo_service.find_by_id(dto.repo_id)
     tag = tag_service.find_by_name_and_repo_id(dto.tag_name, dto.repo_id)
 
-    if not access_control_service.has_delete_tag_access(user_id, repo.id):
+    if not access_control_service.has_delete_access(user_id, repo.id):
         raise AccessDeniedException(f"User {user_id} cannot delete a tag {tag.name} of repository with identifier {repo.id}")
 
     response = await registry_service.delete_tag(registry_client, username, repo, tag)   

--- a/server/app/api/registry/registry_controller.py
+++ b/server/app/api/registry/registry_controller.py
@@ -12,6 +12,7 @@ from app.api.repo.repo_service import RepositoryService, get_repo_service
 from app.api.access_control.access_control_service import AccessControlService, get_access_control_service
 from app.api.config.exception_handler import AccessDeniedException
 from app.api.registry.registry_client import RegistryClient, get_registry_client
+from app.api.jobs.jobs_client import JobsClient, get_jobs_client
 
 internal_router = APIRouter(prefix="/registry", tags=["dockerhub-registry"])
 external_router = APIRouter(prefix="/registry", tags=["dockerhub-registry-external"])
@@ -73,4 +74,17 @@ async def delete_tag_endpoint(
 
     response = await registry_service.delete_tag(registry_client, username, repo, tag)   
 
+    return response
+
+@external_router.delete("/repository/{repo_id}", status_code=202, summary="Delete a repository by its id", response_model=DeleteResponseDTO)
+@pre_authorize([UserRole.user, UserRole.admin])                             
+def delete_repo_endpoint(
+    jwt: JWTDep,
+    repo_id: int,
+    jobs_client: JobsClient = Depends(get_jobs_client),
+    registry_service: RegistryService = Depends(get_registry_service), 
+):
+    username = get_username_from_jwt(jwt)
+    user_id = get_id_from_jwt(jwt)
+    response = registry_service.delete_repo(jobs_client, username, user_id, repo_id)   
     return response

--- a/server/app/api/registry/registry_dto.py
+++ b/server/app/api/registry/registry_dto.py
@@ -16,5 +16,5 @@ class DeleteTagDTO(BaseModel):
     repo_id: int
     tag_name: str
 
-class DeleteTagResponseDTO(BaseModel):
+class DeleteResponseDTO(BaseModel):
     message: str

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import List
 
 from rq import Retry
@@ -6,7 +5,7 @@ from fastapi import Depends, HTTPException
 from app.api.config.exception_handler import AccessDeniedException
 from app.api.jobs.jobs_client import JobsClient
 from app.api.events.event_service import EventService
-from app.api.jobs.jobs_service import delete_tag_job
+from app.api.jobs.jobs_service import JobsService
 from app.api.events.event_model import EventLevel
 from sqlmodel import Session
 from app.api.config.database import get_database
@@ -41,6 +40,7 @@ class RegistryService:
         self.tag_service = TagService(session)
         self.access_control_service = AccessControlService(session)
         self.event_service = EventService()
+        self.jobs_service = JobsService()
 
     def _format_registry_event(self, username: str, action: str, repo_name: str, tag_name: str | None, digest: str, method: str, url: str | None):
 
@@ -194,7 +194,7 @@ class RegistryService:
             for tag in repo.tags:
                 queue = client.get("delete_tag")
                 queue.enqueue(
-                    delete_tag_job, 
+                    self.jobs_service.delete_tag_job, 
                     args=(username, repo.id, tag.name),
                     retry=Retry(max=6, interval=[60, 60, 60, 120, 4*3600])
                 )

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -190,7 +190,7 @@ class RegistryService:
             self.repo_service.remove_repo(repo)
             self.event_service.log(EventLevel.Info, f"Repository '{name}' is deleted.")
         else:
-            self.repo_service.update_repo_by_id(repo.id, deleting=True)
+            self.repo_service.update_repo_attrs(repo.id, deleting=True)
             for tag in repo.tags:
                 queue = client.get("delete_tag")
                 queue.enqueue(

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -171,13 +171,13 @@ class RegistryService:
         digest = await self._fetch_manifest_digest(client, repo.canonical_name, tag.name, username)   
         if digest is None:
             self.tag_service.remove_tag(tag.id)
-            return DeleteResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.name}'.")
+            return DeleteResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.canonical_name}'.")
 
         # Since deletion of the manifest is accepted (202) 
         # by Distribution, it is a slightly better approach 
         # to delete it from the backend database afterward.
         await self._delete_manifest_by_digest(client, repo.canonical_name, digest, username)
-        return DeleteResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.name}'.")
+        return DeleteResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.canonical_name}'.")
    
     def delete_repo(self, client: JobsClient, username: str, user_id: int, repo_id: int) -> DeleteResponseDTO:
         repo = self.repo_service.find_by_id(repo_id)

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -1,5 +1,13 @@
+import asyncio
 from typing import List
+
+from rq import Retry
 from fastapi import Depends, HTTPException
+from app.api.config.exception_handler import AccessDeniedException
+from app.api.jobs.jobs_client import JobsClient
+from app.api.events.event_service import EventService
+from app.api.jobs.jobs_service import delete_tag_job
+from app.api.events.event_model import EventLevel
 from sqlmodel import Session
 from app.api.config.database import get_database
 from app.api.access_control.access_control_service import AccessControlService
@@ -32,6 +40,7 @@ class RegistryService:
         self.repo_service = RepositoryService(session)
         self.tag_service = TagService(session)
         self.access_control_service = AccessControlService(session)
+        self.event_service = EventService()
 
     def _format_registry_event(self, username: str, action: str, repo_name: str, tag_name: str | None, digest: str, method: str, url: str | None):
 
@@ -71,14 +80,19 @@ class RegistryService:
         if action == 'push' and tag_name is not None:
             user = self.user_service.find_by_username(username)
             repo = self.repo_service.find_by_canonical_name(repo_name)
-            tag = self.tag_service.on_push(user.id, repo.id, tag_name)
-            print(f"Pushed tag {tag}")
+            self.tag_service.on_push(user.id, repo.id, tag_name)
+            self.event_service.log(EventLevel.Info, f"Tag '{tag_name}' of repository '{repo.canonical_name}' is pushed.")
 
         elif action == 'delete' and tag_name is not None:
             repo = self.repo_service.find_by_canonical_name(repo_name)
             tag = self.tag_service.find_by_name_and_repo_id(tag_name, repo.id)
             self.tag_service.remove_tag(tag.id)
-            print(f"Deleted tag {tag_name}")
+            self.event_service.log(EventLevel.Info, f"Tag '{tag_name}' of repository '{repo.canonical_name}' is deleted.")
+
+            if repo.deleting and len(repo.tags) == 0:
+                name = repo.canonical_name
+                self.repo_service.remove_repo(repo)
+                self.event_service.log(EventLevel.Info, f"Repository '{name}' is deleted.")
 
         message = self._format_registry_event(username, action, repo_name, tag_name, digest, method, url)
         print(message)
@@ -165,5 +179,27 @@ class RegistryService:
         await self._delete_manifest_by_digest(client, repo.canonical_name, digest, username)
         return DeleteResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.name}'.")
    
+    def delete_repo(self, client: JobsClient, username: str, user_id: int, repo_id: int) -> DeleteResponseDTO:
+        repo = self.repo_service.find_by_id(repo_id)
+
+        if not self.access_control_service.has_delete_access(user_id, repo_id):
+            raise AccessDeniedException(f"User {username} cannot delete a repository with identifier {repo_id}.")
+
+        if len(repo.tags) == 0:
+            name = repo.canonical_name
+            self.repo_service.remove_repo(repo)
+            self.event_service.log(EventLevel.Info, f"Repository '{name}' is deleted.")
+        else:
+            self.repo_service.update_repo_by_id(repo.id, deleting=True)
+            for tag in repo.tags:
+                queue = client.get("delete_tag")
+                queue.enqueue(
+                    delete_tag_job, 
+                    args=(username, repo.id, tag.name),
+                    retry=Retry(max=6, interval=[60, 60, 60, 120, 4*3600])
+                )
+
+        return DeleteResponseDTO(message=f"Request to delete repository '{repo.canonical_name}' has been accepted and will be processed shortly.")
+
 def get_registry_service(session: Session = Depends(get_database)) -> RegistryService:
     return RegistryService(session)

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -6,7 +6,7 @@ from app.api.access_control.access_control_service import AccessControlService
 from app.api.registry.registry_utils import build_manifest_jwt, parse_scopes, build_jwt_for_docker_registry
 from app.api.user.user_service import UserService
 from app.api.repo.repo_service import RepositoryService
-from app.api.registry.registry_dto import DeleteTagResponseDTO, RegistryActionOperation
+from app.api.registry.registry_dto import DeleteResponseDTO, RegistryActionOperation
 from app.api.tags.tag_service import TagService
 from app.api.repo.repo_model import Repository
 from app.api.tags.tag_model import Tag
@@ -148,7 +148,7 @@ class RegistryService:
         response = await client.delete_manifest(repo_name, digest, jwt)
         assert response.status_code == 202
 
-    async def delete_tag(self, client: RegistryClient, username: str, repo: Repository, tag: Tag) -> DeleteTagResponseDTO:
+    async def delete_tag(self, client: RegistryClient, username: str, repo: Repository, tag: Tag) -> DeleteResponseDTO:
         # If the manifest for a certain tag can't be found,
         # it means the manifest has already been deleted.
         # Two tags can point to the same manifest.
@@ -157,13 +157,13 @@ class RegistryService:
         digest = await self._fetch_manifest_digest(client, repo.canonical_name, tag.name, username)   
         if digest is None:
             self.tag_service.remove_tag(tag.id)
-            return DeleteTagResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.name}'.")
+            return DeleteResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.name}'.")
 
         # Since deletion of the manifest is accepted (202) 
         # by Distribution, it is a slightly better approach 
         # to delete it from the backend database afterward.
         await self._delete_manifest_by_digest(client, repo.canonical_name, digest, username)
-        return DeleteTagResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.name}'.")
+        return DeleteResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.name}'.")
    
 def get_registry_service(session: Session = Depends(get_database)) -> RegistryService:
     return RegistryService(session)

--- a/server/app/api/repo/repo_model.py
+++ b/server/app/api/repo/repo_model.py
@@ -18,7 +18,7 @@ class RepositoryStar(SQLModel, table=True):
     __tablename__ = "repository_stars"
 
     starrer_id: int | None = Field(default=None, foreign_key="user.id", primary_key=True)
-    repository_id: int | None = Field(default=None, foreign_key="repository.id", primary_key=True)
+    repository_id: int | None = Field(default=None, foreign_key="repository.id", primary_key=True, ondelete="CASCADE")
 
     starrer: "User" = Relationship(back_populates="stars")
     repository: "Repository" = Relationship()

--- a/server/app/api/repo/repo_model.py
+++ b/server/app/api/repo/repo_model.py
@@ -60,6 +60,7 @@ class Repository(SQLModel, table=True):
     last_updated: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     stars: int = Field(default=0)
     downloads: int = Field(default=0)
+    deleting: bool = Field(default=False)
 
     tags: List["Tag"] = Relationship(back_populates="repository")
 

--- a/server/app/api/repo/repo_repo.py
+++ b/server/app/api/repo/repo_repo.py
@@ -82,3 +82,14 @@ class RepositoryRepo:
         )
 
         return self.session.exec(query).all()
+    
+    def set_attribute(self, repo: Repository, attribute: str, value: any) -> Repository:
+        repo.sqlmodel_update({attribute: value})
+        self.session.add(repo)
+        self.session.commit()
+        self.session.refresh(repo)
+        return repo
+    
+    def remove(self, repo: Repository) -> None:
+        self.session.delete(repo)
+        self.session.commit()

--- a/server/app/api/repo/repo_service.py
+++ b/server/app/api/repo/repo_service.py
@@ -108,7 +108,7 @@ class RepositoryService:
         repo = self._update_repo_attribute(repo, dto)
         return repo
     
-    def update_repo_by_id(self, repo_id: int, **kwargs) -> Repository:
+    def update_repo_attrs(self, repo_id: int, **kwargs) -> Repository:
         repo = self.find_by_id(repo_id)
         for attr, value in kwargs.items():
             repo = self.repo_repo.set_attribute(repo, attr, value)

--- a/server/app/api/repo/repo_service.py
+++ b/server/app/api/repo/repo_service.py
@@ -107,6 +107,12 @@ class RepositoryService:
         repo = self.find_by_id(repo_id)
         repo = self._update_repo_attribute(repo, dto)
         return repo
+    
+    def update_repo_by_id(self, repo_id: int, **kwargs) -> Repository:
+        repo = self.find_by_id(repo_id)
+        for attr, value in kwargs.items():
+            repo = self.repo_repo.set_attribute(repo, attr, value)
+        return repo
 
     def is_repo_starred_by(self, repo: Repository, user: User) -> bool:
         return any(star.repository.id == repo.id for star in user.stars)
@@ -138,6 +144,9 @@ class RepositoryService:
     def get_starred_repositories_of_user(self, user_id: int) -> List[Repository]:
         user_repos = self.repo_repo.find_user_starred_repos(user_id)
         return user_repos
+    
+    def remove_repo(self, repo: Repository) -> None:
+        self.repo_repo.remove(repo)
     
 def get_repo_service(session: Session = Depends(get_database)) -> RepositoryService:
     return RepositoryService(session)

--- a/server/app/api/tags/tag_model.py
+++ b/server/app/api/tags/tag_model.py
@@ -11,7 +11,7 @@ class Tag(SQLModel, table=True):
     name: Optional[str] = Field(default=None)
     last_push: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
-    repository_id: int = Field(foreign_key="repository.id")
+    repository_id: int = Field(foreign_key="repository.id", ondelete="CASCADE")
     repository: "Repository" = Relationship(back_populates="tags")
 
     last_pushed_by_id: int = Field(default=None, foreign_key="user.id")

--- a/server/app/api/team/team_model.py
+++ b/server/app/api/team/team_model.py
@@ -22,7 +22,7 @@ class TeamMember(SQLModel, table=True):
 
 class TeamPermission(SQLModel, table=True):
     team_id: int | None = Field(default=None, foreign_key="team.id", primary_key=True)
-    repo_id: int | None = Field(default=None, foreign_key="repository.id", primary_key=True)
+    repo_id: int | None = Field(default=None, foreign_key="repository.id", primary_key=True, ondelete="CASCADE")
 
     kind: TeamPermissionKind = Field(default=TeamPermissionKind.read)
 

--- a/server/app/tests/test_jobs.py
+++ b/server/app/tests/test_jobs.py
@@ -1,0 +1,236 @@
+import asyncio
+from app.api.events.event_model import EventLevel
+import pytest
+from app.api.events.event_service import EventService
+from app.api.jobs.jobs_service import JobsService
+from sqlmodel import SQLModel
+from unittest.mock import MagicMock
+from app.api.registry.registry_service import RegistryService
+from app.api.registry.registry_dto import DeleteResponseDTO
+from app.api.user.user_service import UserService
+from app.api.repo.repo_service import RepositoryService
+from app.api.access_control.access_control_service import AccessControlService
+from app.api.registry.registry_client import RegistryClient
+from app.api.config.exception_handler import NotFoundException, NotInRelationshipException, RegistryException
+from app.api.repo.repo_model import Repository
+from app.api.tags.tag_model import Tag
+from app.api.tags.tag_service import TagService
+
+@pytest.fixture
+def jobs_service() -> JobsService:
+    service = JobsService()
+    return service
+
+@pytest.fixture
+def registry_service() -> RegistryService:
+    mock_session = MagicMock()
+    service = RegistryService(mock_session)
+    
+    service.user_service = MagicMock(UserService)
+    service.repo_service = MagicMock(RepositoryService)
+    service.access_control_service = MagicMock(AccessControlService)
+    service.tag_service = MagicMock(TagService)
+    service.event_service = MagicMock(EventService)
+
+    return service
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_db():
+    from app.api.config.database import engine
+    SQLModel.metadata.drop_all(bind=engine)
+    SQLModel.metadata.create_all(bind=engine)
+
+class TestGetCurrentJobMetadata:
+
+    def test_job_is_known(self, monkeypatch, jobs_service):
+        """ Test case for when the job is known. """
+        class JobMock:
+            def __init__(self, id, origin, retries_left):
+                self.id = id
+                self.origin = origin
+                self.retries_left = retries_left
+
+        job = JobMock(id="123", origin="delete_tag", retries_left=5)
+        monkeypatch.setattr("app.api.jobs.jobs_service.get_current_job", lambda: job)
+        result = jobs_service._get_current_job_metadata()
+        assert result == {
+            "id": "123",
+            "origin": "delete_tag",
+            "retries_left": 5
+        }
+
+    def test_job_is_unknown(self, monkeypatch, jobs_service):
+        """ Test case for when the job is unknown. """
+        monkeypatch.setattr("app.api.jobs.jobs_service.get_current_job", lambda: None)
+        result = jobs_service._get_current_job_metadata()
+        assert result == {
+            "id": "unknown",
+            "origin": "unknown",
+            "retries_left": "unknown"
+        }
+
+class TestDeleteTagJob:
+
+    def test_repo_not_exist(self, monkeypatch, jobs_service, registry_service):
+        """ Test case for when the repository does not exist. """
+        repo_id = 99999
+        tag_name = "tag"
+        username = "user"
+        mock_client = MagicMock(spec=RegistryClient)
+        mock_session = MagicMock()
+        mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        monkeypatch.setattr(
+            "app.api.jobs.jobs_service.init_registry_client", 
+            lambda: mock_client
+        )
+        monkeypatch.setattr(
+            "app.api.registry.registry_service.RegistryService",
+            lambda session: registry_service
+        )
+        monkeypatch.setattr(
+            jobs_service, 
+            "_get_session", 
+            lambda: mock_session
+        )
+        monkeypatch.setattr(
+            jobs_service,
+            "_get_event_loop",
+            lambda: mock_loop
+        )
+        registry_service.repo_service.find_by_id.side_effect = NotFoundException(Repository, repo_id)
+
+        jobs_service.delete_tag_job(username, repo_id, tag_name)
+
+        mock_loop.run_until_complete.assert_not_called()
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo_id)
+        registry_service.event_service.log.assert_called_once_with(EventLevel.Info, f"Repository with identifier '{repo_id}' has already been deleted by another job.")
+
+    def test_tag_not_exist(self, monkeypatch, jobs_service, registry_service):
+        """ Test case for when the tag does not exist. """
+        repo_id = 99999
+        username = "user"
+        tag_name = "tag"
+        mock_client = MagicMock(spec=RegistryClient)
+        mock_session = MagicMock()
+        mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        monkeypatch.setattr(
+            "app.api.jobs.jobs_service.init_registry_client", 
+            lambda: mock_client
+        )
+        monkeypatch.setattr(
+            "app.api.registry.registry_service.RegistryService",
+            lambda session: registry_service
+        )
+        monkeypatch.setattr(
+            jobs_service, 
+            "_get_session", 
+            lambda: mock_session
+        )
+        monkeypatch.setattr(
+            jobs_service,
+            "_get_event_loop",
+            lambda: mock_loop
+        )
+        registry_service.tag_service.find_by_name_and_repo_id.side_effect = NotInRelationshipException(Repository, repo_id, Tag, tag_name)
+
+        jobs_service.delete_tag_job(username, repo_id, tag_name)
+    
+        mock_loop.run_until_complete.assert_not_called()
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo_id)
+        registry_service.tag_service.find_by_name_and_repo_id.assert_called_once_with(tag_name, repo_id)
+        registry_service.event_service.log.assert_called_once_with(EventLevel.Info, f"Tag '{tag_name}' has already been deleted by another job.")
+
+    def test_tag_is_deleted(self, monkeypatch, jobs_service, registry_service):
+        """ Test case for when the tag is deleted. """
+
+        mock_client = MagicMock(spec=RegistryClient)
+        mock_session = MagicMock()
+        mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        monkeypatch.setattr(
+            "app.api.jobs.jobs_service.init_registry_client", 
+            lambda: mock_client
+        )
+        monkeypatch.setattr(
+            "app.api.registry.registry_service.RegistryService",
+            lambda session: registry_service
+        )
+        monkeypatch.setattr(
+            jobs_service, 
+            "_get_session", 
+            lambda: mock_session
+        )
+        monkeypatch.setattr(
+            jobs_service,
+            "_get_event_loop",
+            lambda: mock_loop
+        )
+
+        username = "user"
+        repo = MagicMock(spec=Repository(id=1, name="repo"))
+        tag = MagicMock(spec=Tag(id=1, name="tag"))
+        registry_service.repo_service.find_by_id.return_value = repo
+        registry_service.tag_service.find_by_name_and_repo_id.return_value = tag
+        response_dto = DeleteResponseDTO(message=f"Tag '{tag.name}' successfully deleted from repository '{repo.canonical_name}'.")
+        mock_loop.run_until_complete.return_value = response_dto
+
+        jobs_service.delete_tag_job(username, repo.id, tag.name)
+    
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
+        registry_service.tag_service.find_by_name_and_repo_id.assert_called_once_with(tag.name, repo.id)
+        mock_loop.run_until_complete.assert_called_once()
+        registry_service.event_service.log.assert_called_once_with(EventLevel.Info, response_dto.message)
+
+    def test_deleting_tag_raises_unexpected_exception(self, monkeypatch, jobs_service, registry_service):
+        """ Test case for when the tag is being deleted and an unexpected exception occurred. """
+
+        mock_client = MagicMock(spec=RegistryClient)
+        mock_session = MagicMock()
+        mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        monkeypatch.setattr(
+            "app.api.jobs.jobs_service.init_registry_client", 
+            lambda: mock_client
+        )
+        monkeypatch.setattr(
+            "app.api.registry.registry_service.RegistryService",
+            lambda session: registry_service
+        )
+        monkeypatch.setattr(
+            jobs_service, 
+            "_get_session", 
+            lambda: mock_session
+        )
+        monkeypatch.setattr(
+            jobs_service,
+            "_get_event_loop",
+            lambda: mock_loop
+        )
+
+        class JobMock:
+            def __init__(self, id, origin, retries_left):
+                self.id = id
+                self.origin = origin
+                self.retries_left = retries_left
+        job = JobMock(id="123", origin="delete_tag", retries_left=5)
+        monkeypatch.setattr("app.api.jobs.jobs_service.get_current_job", lambda: job)
+
+        username = "user"
+        repo = MagicMock(spec=Repository(id=1, name="repo"))
+        tag = MagicMock(spec=Tag(id=1, name="tag"))
+        registry_service.repo_service.find_by_id.return_value = repo
+        registry_service.tag_service.find_by_name_and_repo_id.return_value = tag
+        mock_loop.run_until_complete.side_effect = RegistryException(502, "distribution is not available")
+
+        with pytest.raises(RegistryException): 
+            jobs_service.delete_tag_job(username, repo.id, tag.name)
+    
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
+        registry_service.tag_service.find_by_name_and_repo_id.assert_called_once_with(tag.name, repo.id)
+        mock_loop.run_until_complete.assert_called_once()
+        registry_service.event_service.log.assert_called_once_with(
+            EventLevel.Error, 
+            (
+                f"Tag '{tag.name}' is not deleted (job_id={job.id}, retries_left={job.retries_left}, queue={job.origin}). " 
+                f"ADMIN: For an immediate response, check both the queue dashboard and the log trace."
+            )
+        )
+

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -755,8 +755,6 @@ class TestDeleteRepo:
             r2 = add_repo("u1", "r2", o1["id"])
             r3 = add_repo("u1", "r3", o1["id"])
             r4 = add_repo("u1", "r4", o1["id"])
-            print(f"u1 {u1}")
-            print(f"r4 {r4}")
             add_tag(u1["id"], r2["id"], "t1")
             add_tag(u1["id"], r2["id"], "t2")
             add_tag(u1["id"], r4["id"], "t3")

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -653,6 +653,151 @@ class TestDeleteRepo:
         registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
         registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
         registry_service.repo_service.update_repo_attrs.assert_called_once_with(repo.id, deleting=True)
+
+    @patch("app.api.jobs.jobs_client.JobsClient.get", return_value=MagicMock())
+    def test_delete_repo__integration(self, mock_get_queue):
+
+        # NOTE: Queues are mocked in these tests, as  
+        # spinning up Redis and workers is very complex.
+
+        with TestClient(app) as client:
+            def add_user(username):
+                data = {
+                    "username": username,
+                    "email": f"{username}@email.com",
+                    "password": "1234"
+                }
+                response = client.post("/api/v1/users/", json=data)
+                return response.json()
+
+            def log_in(username):
+                data = {"username": username, "password": "1234"}
+                response = client.post("/api/v1/users/login", json=data)
+                return response.json()["token"]
+
+            def add_repo(username, repo_name, org_id = None):
+                data = {
+                    "name": repo_name,
+                    "desc": "",
+                    "public": True,
+                    "organization_id": org_id,
+                }
+                header = {"Authorization": f"Bearer {log_in(username)}"}
+
+                return client.post("/api/v1/repositories/", json=data, headers=header).json()
+            
+            def add_org(username, name: str) -> dict:
+                jwt = log_in(username)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+                dto = {
+                    "name": name,
+                    "desc": "",
+                    "image": None
+                }
+                return client.post("/api/v1/organizations", json=dto, headers=header).json()
+
+            def add_user_to_org(user_id: int, org_id: int) -> OrganizationMembers:
+                # TODO: Once we implement "add user to org" in the controller, use the proper endpoint for that here.
+                from app.api.config.database import engine
+                from app.api.org.org_repo import OrganizationRepo
+                from app.api.config.database import get_database
+
+                session = next(get_database())
+                org_repo = OrganizationRepo(session)
+                return org_repo.add_user_to_org(org_id, user_id)
+
+            def add_team(username: str, org_id: int, name: str, desc: str = "") -> dict:
+                jwt = log_in(username)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+                dto1 = {
+                    "organization_id": org_id,
+                    "name": name,
+                    "desc": desc,
+                }
+                return client.post("/api/v1/teams", json=dto1, headers=header).json()
+
+            def add_team_member(user_id: int, team_id: int) -> TeamMember:
+                # TODO: Once we implement "add team_member" in the controller, use the proper endpoint for that here.
+                from app.api.team.team_repo import TeamRepo
+                from app.api.config.database import get_database
+
+                session = next(get_database())
+                team_repo = TeamRepo(session)
+                return team_repo.add_member(team_id, user_id)
+            
+            def add_team_permission(team_id: int, repo_id: int, kind: TeamPermissionKind) -> TeamPermission:
+                # TODO: Once we implement "add_team_permission" in the controller, use the proper endpoint for that here.
+                from app.api.team.team_repo import TeamRepo
+                from app.api.config.database import get_database
+
+                session = next(get_database())
+                team_repo = TeamRepo(session)
+                return team_repo.add_permission(team_id, repo_id, kind).model_dump()
+
+            def add_tag(user_id, repo_id, tag_name):
+                session = next(get_database())
+                tag_service = TagService(session)
+                return tag_service.on_push(user_id, repo_id, tag_name).model_dump()
+            
+            
+
+            def delete_repo(repo_id, username):
+                header = {"Authorization": f"Bearer {log_in(username)}"}
+                return client.request("DELETE", f"/api/v1/registry/repository/{repo_id}", headers=header)
+
+            u1 = add_user("u1")
+            u2 = add_user("u2")
+            u3 = add_user("u3")
+            o1 = add_org("u1", "o1")
+            r1 = add_repo("u1", "r1")
+            r2 = add_repo("u1", "r2", o1["id"])
+            r3 = add_repo("u1", "r3", o1["id"])
+            r4 = add_repo("u1", "r4", o1["id"])
+            print(f"u1 {u1}")
+            print(f"r4 {r4}")
+            add_tag(u1["id"], r2["id"], "t1")
+            add_tag(u1["id"], r2["id"], "t2")
+            add_tag(u1["id"], r4["id"], "t3")
+            add_tag(u1["id"], r4["id"], "t4")
+
+            add_user_to_org(u3["id"], o1["id"])
+            t1 = add_team("u1", o1["id"], "t1")
+            add_team_member(u3["id"], t1["id"])
+            add_team_permission(t1["id"], r3["id"], TeamPermissionKind.admin)
+            add_team_permission(t1["id"], r4["id"], TeamPermissionKind.read_write)
+
+            # 1) Repository does not exist.
+            response = delete_repo(99999, u1["username"])
+            assert response.status_code == 404
+            assert mock_get_queue.call_count == 0
+
+            # 2) User is not authorized to delete the repository.
+            response = delete_repo(r1["id"], u2["username"])
+            assert response.status_code == 400
+            assert mock_get_queue.call_count == 0
+
+            # 3) User removes a repository without tags successfully.
+            with patch("app.api.events.event_service.EventService.log"):
+                response = delete_repo(r1["id"], u1["username"])
+                assert response.status_code == 202
+                assert mock_get_queue.call_count == 0
+
+            with patch("app.api.events.event_service.EventService.log"):
+                response = delete_repo(r3["id"], u3["username"])
+                assert response.status_code == 202
+                assert mock_get_queue.call_count == 0
+
+            # 4) User removes a repository with tags successfully.
+            response = delete_repo(r2["id"], u1["username"])
+            assert response.status_code == 202
+            assert mock_get_queue.call_count == 2   
+
+            response = delete_repo(r4["id"], u3["username"])
+            assert response.status_code == 202
+            assert mock_get_queue.call_count == 4   
+
 # -----------------------------------
 # Util functions
 # -----------------------------------

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -1,19 +1,23 @@
 import os
 from fastapi.testclient import TestClient
 import jwt
+from app.api.events.event_model import EventLevel
 import pytest
+from app.api.jobs.jobs_client import JobsClient
+from app.api.user.user_model import User
+from app.api.events.event_service import EventService
 from sqlmodel import SQLModel
 from app.api.main import app
 from unittest.mock import MagicMock, AsyncMock, call, patch
 from fastapi import HTTPException
 from app.api.registry.registry_service import RegistryService
-from app.api.registry.registry_dto import RegistryActionOperation
+from app.api.registry.registry_dto import DeleteResponseDTO, RegistryActionOperation
 from app.api.user.user_service import UserService
 from app.api.repo.repo_service import RepositoryService
 from app.api.access_control.access_control_service import AccessControlService
 from app.api.registry.registry_utils import build_jwt_for_docker_registry, parse_scopes, build_manifest_jwt
 from app.api.registry.registry_client import RegistryClient
-from app.api.config.exception_handler import RegistryException
+from app.api.config.exception_handler import AccessDeniedException, NotFoundException, RegistryException
 from app.api.repo.repo_model import Repository
 from app.api.tags.tag_model import Tag
 from httpx import AsyncClient, Response, Request
@@ -33,7 +37,9 @@ def registry_service() -> RegistryService:
     service.user_service = MagicMock(UserService)
     service.repo_service = MagicMock(RepositoryService)
     service.access_control_service = MagicMock(AccessControlService)
-    
+    service.tag_service = MagicMock(TagService)
+    service.event_service = MagicMock(EventService)
+
     return service
 
 @pytest.fixture
@@ -569,6 +575,84 @@ class TestDeleteTag:
             # 8) Delete tag as an organization member with `read_write` permissions.
             standard_deleting_test(r3, t4, u2)
 
+class TestDeleteRepo:
+    
+    def test_repo_not_exist(self, registry_service: RegistryService):
+        """ Test case for when the repository does not exist. """
+        client = MagicMock(spec=JobsClient)
+        user_id = 1
+        repo_id = 99999
+        registry_service.repo_service.find_by_id.side_effect = NotFoundException(Repository, repo_id)
+
+        with pytest.raises(NotFoundException): 
+            registry_service.delete_repo(client, "user", user_id, repo_id)
+    
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo_id)
+
+    def test_user_not_permitted(self, registry_service: RegistryService):
+        """ Test case for when the user is not permitted to delete the repository. """
+        repo = MagicMock(spec=Repository)
+        client = MagicMock(spec=JobsClient)
+        registry_service.repo_service.find_by_id.return_value = repo
+        user_id = 1
+        repo.id = 1
+        registry_service.access_control_service.has_delete_access.return_value = False
+
+        with pytest.raises(AccessDeniedException): 
+            registry_service.delete_repo(client, "user", user_id, repo.id)
+    
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
+        registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
+        
+    def test_repo_not_have_tags(self, registry_service: RegistryService):
+        """ Test case for when the repository does not have any tags. """
+        user_id = 1
+        client = MagicMock(spec=JobsClient)
+        repo = MagicMock(spec=Repository)
+        repo.id =1
+        repo.name = "repo"
+        repo.owner = MagicMock(spec=User)
+        repo.owner.username = "user"
+        repo.tags = []
+        registry_service.repo_service.find_by_id.return_value = repo
+        registry_service.repo_service.remove_repo.return_value = None
+
+        result = registry_service.delete_repo(client, "user", user_id, repo.id)
+
+        assert isinstance(result, DeleteResponseDTO)
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
+        registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
+        registry_service.repo_service.remove_repo.assert_called_once_with(repo)
+        registry_service.event_service.log.assert_called_once_with(EventLevel.Info, f"Repository '{repo.canonical_name}' is deleted.")
+
+    def test_repo_has_tags(self, registry_service: RegistryService):
+        """ Test case for when the repository has tags. """
+        user_id = 1
+        tag_1 = MagicMock(spec=Tag(name="tag_1"))
+        tag_2 = MagicMock(spec=Tag(name="tag_2"))
+        
+        repo = MagicMock(spec=Repository)
+        repo.id = 1
+        repo.name = "repo"
+        repo.owner = MagicMock(spec=User)
+        repo.owner.username = "user"
+        repo.tags = [tag_1, tag_2]
+
+        queue = MagicMock()
+        client = MagicMock(spec=JobsClient)
+        client.get.return_value = queue
+
+        registry_service.repo_service.find_by_id.return_value = repo
+        registry_service.repo_service.remove_repo.return_value = None
+
+        result = registry_service.delete_repo(client, "user", user_id, repo.id)
+
+        assert isinstance(result, DeleteResponseDTO)
+        assert queue.enqueue.call_count == 2
+        client.get.assert_called_with("delete_tag")
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
+        registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
+        registry_service.repo_service.update_repo_attrs.assert_called_once_with(repo.id, deleting=True)
 # -----------------------------------
 # Util functions
 # -----------------------------------

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -1219,3 +1219,79 @@ class TestIsRepoStarredBy:
 
         result = repo_service.is_repo_starred_by(r1, user)
         assert result is True
+
+class TestUpdateRepoAttrs():
+        
+    def test_repo_not_exist(self, repo_service):
+        """ Test case for when the repository does not exist. """
+        repo_id = 1
+        repo_service.repo_repo.find_by_id.return_value = None
+
+        with pytest.raises(NotFoundException):
+            repo_service.update_repo_attrs(repo_id, desc="desc123")
+        
+        repo_service.repo_repo.find_by_id.assert_called_once_with(repo_id)
+
+    def test_attributes_not_passed(self, repo_service):
+        """ Test case for when no attributes are passed. """ 
+        repo = mock.MagicMock(spec=Repository)
+        repo.id = 1
+        repo.name = "repo"
+        repo.desc = "desc"
+        repo.public = True
+        repo_service.repo_repo.find_by_id.return_value = repo
+
+        result = repo_service.update_repo_attrs(repo.id)
+
+        assert result == repo 
+        assert result.id == repo.id
+        assert result.name == repo.name
+        assert result.desc == repo.desc
+        assert result.public == repo.public
+        repo_service.repo_repo.find_by_id.assert_called_once_with(repo.id)
+
+    def test_attribute_not_exist(self, repo_service):
+        """ Test case for when a specified attribute does not exist. """  
+        repo = mock.MagicMock(spec=Repository)
+        repo.id = 1
+        repo.name = "repo"
+        repo.desc = "desc"
+        repo.public = True
+        repo_service.repo_repo.find_by_id.return_value = repo
+        repo_service.repo_repo.set_attribute.side_effect = ValueError("unknown attribute")
+
+        with pytest.raises(ValueError) as e: 
+            repo_service.update_repo_attrs(repo.id, unknown_attr="fail")
+        
+        assert "unknown attribute" in str(e.value)
+        repo_service.repo_repo.find_by_id.assert_called_once_with(repo.id)
+        repo_service.repo_repo.set_attribute.assert_called_once_with(repo, "unknown_attr", "fail")
+    
+    def test_successfully_update_attributes(self, repo_service):
+        """ Test case for when the attributes exist. """
+        repo = mock.MagicMock(spec=Repository)
+        repo.id = 1
+        repo.name = "repo"
+        repo.desc = "desc"
+        repo.public = True
+        repo_service.repo_repo.find_by_id.return_value = repo
+
+        def mock_set_attribute(repo, attr, value):
+            setattr(repo, attr, value)
+            return repo
+        repo_service.repo_repo.set_attribute.side_effect = mock_set_attribute
+
+        result = repo_service.update_repo_attrs(repo.id, name="new_name", desc="new_desc", public=False)
+
+        assert result.id == 1
+        assert result.public is False
+        assert result.name == "new_name"
+        assert result.desc == "new_desc"
+        repo_service.repo_repo.find_by_id.assert_called_once_with(repo.id)
+        expected_calls = [
+            mock.call(repo, "name", "new_name"), 
+            mock.call(repo, "desc", "new_desc"), 
+            mock.call(repo, "public", False),
+        ]
+        assert repo_service.repo_repo.set_attribute.call_args_list == expected_calls
+    

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -9,6 +9,7 @@ pyjwt
 cryptography
 
 fastapi-cache2[redis]
+rq
 
 pytest
 pytest-asyncio

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,0 @@
-FROM python:3.10.15-alpine3.20
-
-COPY worker.py /
-
-RUN pip install --no-cache-dir rq redis
-
-CMD ["python", "worker.py"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10.15-alpine3.20
+
+COPY worker.py /
+
+RUN pip install --no-cache-dir rq redis
+
+CMD ["python", "worker.py"]

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1,0 +1,13 @@
+import os
+from redis import Redis
+from rq import Worker, Queue
+
+scheme = os.environ["REDIS_SCHEME"]
+host = os.environ["REDIS_HOST"]
+port = os.environ["REDIS_PORT"]
+connection = Redis.from_url(f"{scheme}://{host}:{port}")
+
+if __name__ == '__main__':
+    default_queue = [Queue(name, connection=connection) for name in ['default']]
+    worker = Worker(queues=default_queue, connection=connection)
+    worker.work()


### PR DESCRIPTION
Closes #31.

- Added cascade cleaning as it promotes minimal code, and we don’t need to think about it. We want cascade deletion of `RepositoryStar`, `TeamPermission`, and `Tag` instances upon `Repository` deletion.
- I was unsure about where to place`jobs`. For now, I have chosen this option. Even though jobs should ideally be located outside `api`, we also have config under `api`, so otherwise I would need to create an additional `config` directory within the `app` directory.
- I was also unsure about placing `delete_tag_job`. Maybe this decision is best, as it provides scalability, even though we said that we wouldn’t import `RegistryService`, which this solution does not satisfy. If anyone has a better idea, I’m ready to reorganize the code. For more information, check this [commit](https://github.com/magley/mocker-hub/commit/e42047ceef8fd8dce58bcf25069fafb896d0302a). After review, I will write tests related to `jobs`.
- I have added a `worker` for executing jobs and `rq-dashboard` for managing them. This will be especially useful if a job fails and the admin needs to react. My focus was on generating logs, so the admin can spot job failures from the logs dashboard and investigate and manage jobs more deeply via `rq-dashboard`. Therefore, some tags may break during deletion, where a few tags will still appear available, but will soon be deleted upon admin reaction. This is an extreme situation, but still acceptable. With this approach, we promote eventual consistency, which in my opinion is a fine solution.
- The `worker` has a strange implementation, but it can’t run under the `backend`, as only one service can run per container. Also, the `backend` would be overconsumed at certain moments. Therefore, the `worker` should be outside. I faced many errors, as a bit more complex jobs require a larger codebase. I just shared everything that seems to be the best decision, as it’s sustainable in the long term. I chose to share all volumes and variables, as missing any would likely cause the `worker` to fail. There should just be a caveat related to concurrency in file writing when adding new jobs.
- Using `BackgroundTasks` would likely offer a simpler implementation, but at a glance, I thought the current setup would provide a less complex design overall.
- If you get a blank, fully minimalistic, and non-functional `rq-dashboard`, force a cache rebuild (`Ctrl + F5`) or open it in an incognito window.

_____

- I have spotted a strange situation with the Docker client and layer mounting. Assume that we have a layer common to `repoA`, `repoB`, and `repoC`. When the image with the common layer is first pushed to `repoA`, the layer is uploaded. After that, when pushing to `repoB`, the layer from `repoA` will be mounted. Later, if an image is pushed to `repoC`, the layer is mounted from `repoB` instead of `repoA`?! This happens because the Docker client has a local cache where it tracks repositories, images, and layers. As a result, the Docker client will request our auth API to allow cross-repository mounting—specifically, a `repoB` pull during the push to `repoC`. As we don’t currently support transitive layer tracking, the request will be rejected.

- After some research, the easiest solution is for the user to clean the Docker client cache (I tried, but didn’t succeed) or to use a client that forces re-pushing when it lacks mounting permission—like [Skopeo](https://github.com/containers/skopeo). If we use Skopeo, the layers won’t be literally reuploaded, because the `registry` (Distribution) will detect that the layers already exist and skip the reupload.