### PR TITLE
Feature delete organization

### DIFF
--- a/client/src/api/org.api.ts
+++ b/client/src/api/org.api.ts
@@ -32,6 +32,10 @@ export interface OrganizationHasMemberDTO {
     is_member: boolean
 }
 
+export interface DeleteOrgResponseDTO {
+    message: string
+}
+
 export class OrganizationService {
     static async CreateOrganization(dto: OrganizationCreateDTO): Promise<AxiosResponse<OrganizationDTOBasic>> {
         return await axiosInstance.post(`/organizations`, dto);
@@ -51,5 +55,9 @@ export class OrganizationService {
         
     static async AmIMemberOfOrg(org_id: number): Promise<AxiosResponse<OrganizationHasMemberDTO>> {
         return await axiosInstance.get(`/organizations/me/${org_id}`);
+    }
+
+    static async DeleteOrg(orgName: string) : Promise<AxiosResponse<DeleteOrgResponseDTO>> {
+        return await axiosInstance.delete(`/registry/organization/${orgName}`)
     }
 }

--- a/client/src/components/OrgSettings.tsx
+++ b/client/src/components/OrgSettings.tsx
@@ -1,13 +1,25 @@
 import React, { useEffect, useState } from "react";
 import { OrganizationDTOBasic, OrganizationService } from "../api/org.api";
-import { Spinner } from "react-bootstrap";
+import { Button, Card, Spinner } from "react-bootstrap";
+import { AxiosError } from "axios";
+import { ToastType, useToastStore } from "../util/toastStore";
+import { getJwtId } from "../util/localstorage";
 
 export const OrgSettings: React.FC<{ isActive: boolean, org: OrganizationDTOBasic }> = ({ isActive, org }) => {
     const [loading, setLoading] = useState(true);
+    const addToast = useToastStore((state) => state.addToast);
+    const [amOwnerOfOrg, setAmOwnerOfOrg] = useState(false);
+    
+    const checkIfIamOwnerOfOrg = () => {
+        if (getJwtId() === org.owner_id) {
+            setAmOwnerOfOrg(true);
+        }
+    }
 
     useEffect(() => {
         if (isActive) {
             setLoading(false);
+            checkIfIamOwnerOfOrg();
         }
     }, [isActive]);
 
@@ -19,11 +31,38 @@ export const OrgSettings: React.FC<{ isActive: boolean, org: OrganizationDTOBasi
         );
     }
 
+    const handleDeleteOrg = async () => {
+        OrganizationService.DeleteOrg(org.name)
+            .then((res) => {
+                addToast(res.data.message, ToastType.success);
+            })
+            .catch((err: AxiosError) => {
+                const data = (err.response?.data ?? {}) as any;
+                const msg = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                addToast(msg, ToastType.error);
+            })
+    };
+    
     return (
         <>
-            This is where settings go. <br />
-            Desc: {org.desc} <br />
-            <img src={OrganizationService.GetImageURI(org.image)} /> <br />
+            <Card className="mt-4">
+                <Card.Body>
+                    <img src={OrganizationService.GetImageURI(org.image)} /> <br />
+                    Desc: {org.desc} <br />
+                </Card.Body>
+            </Card>
+
+            {amOwnerOfOrg && 
+                <Card className="mt-4">
+                    <Card.Body>
+                        <Card.Title className="d-flex align-items-center">
+                            <h5 className="mb-0">Delete organization</h5>
+                        </Card.Title>
+                        <p className="text-muted mt-3"> Deleting an organization will destroy all information (repositories, images, members, ...) stored within it. This action cannot be undone. </p>
+                        <Button variant="outline-danger" onClick={handleDeleteOrg}>Delete organization</Button>
+                    </Card.Body>
+                </Card>
+            }
         </>
     );
 }

--- a/server/app/api/access_control/access_control_service.py
+++ b/server/app/api/access_control/access_control_service.py
@@ -169,6 +169,12 @@ class AccessControlService:
     # This method handles permission checks for both repository and tag deletions.
     def has_delete_access(self, user_id: int | None, repo_id: int) -> bool:
         return self.has_write_access(user_id, repo_id)    
+    
+    # This method is introduced to handle even the special case where the organization owner  
+    # is eligible to delete a repository as part of the broader organization deletion process.
+    def has_delete_repo_access(self, user_id: int | None, repo: Repository) -> bool:
+        org_owner_delete = repo.organization is not None and repo.organization.deleting and repo.organization.owner.id == user_id
+        return org_owner_delete or self.has_delete_access(user_id, repo.id)
 
 def get_access_control_service(session: Session = Depends(get_database)) -> AccessControlService:
     return AccessControlService(session)

--- a/server/app/api/org/org_model.py
+++ b/server/app/api/org/org_model.py
@@ -10,7 +10,7 @@ class OrganizationMembers(SQLModel, table=True):
     __tablename__ = "organization_members"
 
     user_id: int | None = Field(default=None, foreign_key="user.id", primary_key=True)
-    organization_id: int | None = Field(default=None, foreign_key="organization.id", primary_key=True)
+    organization_id: int | None = Field(default=None, foreign_key="organization.id", primary_key=True, ondelete="CASCADE")  
 
     organization: "Organization" = Relationship(back_populates="members")
     user: "User" = Relationship()
@@ -21,6 +21,7 @@ class Organization(SQLModel, table=True):
 
     name: str = Field()
     desc: str = Field(default="")
+    deleting: bool = Field(default=False)
     image: str = Field(default="")
     """
     Path to the image, relative to the internal `/images/` folder.
@@ -30,4 +31,4 @@ class Organization(SQLModel, table=True):
     owner: "User" = Relationship()
 
     repositories: list["Repository"] = Relationship(back_populates="organization", cascade_delete=True)
-    members: List["OrganizationMembers"] = Relationship(back_populates="organization")
+    members: List["OrganizationMembers"] = Relationship(back_populates="organization", cascade_delete=True)

--- a/server/app/api/org/org_repo.py
+++ b/server/app/api/org/org_repo.py
@@ -47,3 +47,14 @@ class OrganizationRepo:
         query = select(Organization.id, Organization.name).where(Organization.id.in_(ids))
         result = self.session.exec(query).all()
         return {org.id: org.name for org in result}
+    
+    def remove(self, org: Organization) -> None:
+        self.session.delete(org)
+        self.session.commit()
+
+    def set_attribute(self, org: Organization, attribute: str, value: any) -> Organization:
+        org.sqlmodel_update({attribute: value})
+        self.session.add(org)
+        self.session.commit()
+        self.session.refresh(org)
+        return org

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -92,8 +92,8 @@ class OrganizationService:
     def update_org_attrs(self, name: str, **kwargs) -> Organization:
         org = self.find_by_name(name)
         for attr, value in kwargs.items():
-            repo = self.org_repo.set_attribute(org, attr, value)
-        return repo
+            org = self.org_repo.set_attribute(org, attr, value)
+        return org
 
 def get_org_service(session: Session = Depends(get_database)) -> OrganizationService:
     return OrganizationService(session)

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -86,5 +86,14 @@ class OrganizationService:
     def get_org_names_from_repos(self, repos: List[Repository]) -> Dict[int, str]:
         return self.find_org_names_by_ids([r.organization_id for r in repos if r.organization_id is not None])
 
+    def remove_org(self, org: Organization) -> None:
+        self.org_repo.remove(org)
+
+    def update_org_attrs(self, name: str, **kwargs) -> Organization:
+        org = self.find_by_name(name)
+        for attr, value in kwargs.items():
+            repo = self.org_repo.set_attribute(org, attr, value)
+        return repo
+
 def get_org_service(session: Session = Depends(get_database)) -> OrganizationService:
     return OrganizationService(session)

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -77,8 +77,11 @@ class OrganizationService:
     def find_org_names_by_ids(self, ids: List[int]) -> Dict[int, str]:
         return self.org_repo.find_orgs_by_ids(ids)
     
-    def find_by_name(self, org_name: str) -> Organization:
-        return self.org_repo.find_by_name(org_name)
+    def find_by_name(self, name: str) -> Organization:
+        org = self.org_repo.find_by_name(name)
+        if org is None:
+            raise NotFoundException(Organization, name)
+        return org
     
     def is_user_member_of_org(self, org_id: int, user_id: int) -> bool:
         return self.org_repo.user_is_in_org(user_id, org_id)

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -5,7 +5,7 @@ from app.api.config.database import get_database
 from app.api.org.org_dto import OrganizationCreateDTO
 from app.api.org.org_model import Organization, OrganizationMembers
 from app.api.org.org_repo import OrganizationRepo
-from app.api.config.exception_handler import FieldTakenException
+from app.api.config.exception_handler import FieldTakenException, NotFoundException
 from app.api.config.images import generate_inline_image, save_image
 from app.api.repo.repo_model import Repository
  
@@ -91,6 +91,8 @@ class OrganizationService:
 
     def update_org_attrs(self, name: str, **kwargs) -> Organization:
         org = self.find_by_name(name)
+        if org is None:
+            raise NotFoundException(Organization, name)
         for attr, value in kwargs.items():
             org = self.org_repo.set_attribute(org, attr, value)
         return org

--- a/server/app/api/registry/registry_controller.py
+++ b/server/app/api/registry/registry_controller.py
@@ -88,3 +88,16 @@ def delete_repo_endpoint(
     user_id = get_id_from_jwt(jwt)
     response = registry_service.delete_repo(jobs_client, username, user_id, repo_id)   
     return response
+
+@external_router.delete("/organization/{org_name}", status_code=202, summary="Delete an organization by its name", response_model=DeleteResponseDTO)
+@pre_authorize([UserRole.user, UserRole.admin])                             
+def delete_org_endpoint(
+    jwt: JWTDep,
+    org_name: str,
+    jobs_client: JobsClient = Depends(get_jobs_client),
+    registry_service: RegistryService = Depends(get_registry_service), 
+):
+    username = get_username_from_jwt(jwt)
+    user_id = get_id_from_jwt(jwt)
+    response = registry_service.delete_org(jobs_client, username, user_id, org_name) 
+    return response

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -189,12 +189,12 @@ class RegistryService:
    
     def delete_repo(self, client: JobsClient, username: str, user_id: int, repo_id: int) -> DeleteResponseDTO:
         repo = self.repo_service.find_by_id(repo_id)
+        name = repo.canonical_name
 
         if not self.access_control_service.has_delete_access(user_id, repo_id):
             raise AccessDeniedException(f"User {username} cannot delete a repository with identifier {repo_id}.")
 
         if len(repo.tags) == 0:
-            name = repo.canonical_name
             org = repo.organization
             self.repo_service.remove_repo(repo)
             self.event_service.log(EventLevel.Info, f"Repository '{name}' is deleted.")
@@ -214,7 +214,7 @@ class RegistryService:
                     retry=Retry(max=6, interval=[60, 60, 60, 120, 4*3600])
                 )
 
-        return DeleteResponseDTO(message=f"Request to delete repository '{repo.canonical_name}' has been accepted and will be processed shortly.")
+        return DeleteResponseDTO(message=f"Request to delete repository '{name}' has been accepted and will be processed shortly.")
 
     def delete_org(self, client: JobsClient, username: str, user_id: int, org_name: str) -> DeleteResponseDTO:
         org = self.org_service.find_by_name(org_name)

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -7,6 +7,7 @@ from app.api.jobs.jobs_client import JobsClient
 from app.api.events.event_service import EventService
 from app.api.jobs.jobs_service import JobsService
 from app.api.events.event_model import EventLevel
+from app.api.org.org_service import OrganizationService
 from sqlmodel import Session
 from app.api.config.database import get_database
 from app.api.access_control.access_control_service import AccessControlService
@@ -41,6 +42,7 @@ class RegistryService:
         self.access_control_service = AccessControlService(session)
         self.event_service = EventService()
         self.jobs_service = JobsService()
+        self.org_service = OrganizationService(session)
 
     def _format_registry_event(self, username: str, action: str, repo_name: str, tag_name: str | None, digest: str, method: str, url: str | None):
 
@@ -90,9 +92,15 @@ class RegistryService:
             self.event_service.log(EventLevel.Info, f"Tag '{tag_name}' of repository '{repo.canonical_name}' is deleted.")
 
             if repo.deleting and len(repo.tags) == 0:
-                name = repo.canonical_name
+                org = repo.organization
+                repo_name = repo.canonical_name
                 self.repo_service.remove_repo(repo)
-                self.event_service.log(EventLevel.Info, f"Repository '{name}' is deleted.")
+                self.event_service.log(EventLevel.Info, f"Repository '{repo_name}' is deleted.")
+
+                if org.deleting and len(org.repositories) == 0:
+                    org_name = org.name
+                    self.org_service.remove_org(org)
+                    self.event_service.log(EventLevel.Info, f"Organization '{org_name}' is deleted.")
 
         message = self._format_registry_event(username, action, repo_name, tag_name, digest, method, url)
         print(message)
@@ -187,8 +195,15 @@ class RegistryService:
 
         if len(repo.tags) == 0:
             name = repo.canonical_name
+            org = repo.organization
             self.repo_service.remove_repo(repo)
             self.event_service.log(EventLevel.Info, f"Repository '{name}' is deleted.")
+
+            if org.deleting and len(org.repositories) == 0:
+                org_name = org.name
+                self.org_service.remove_org(org)
+                self.event_service.log(EventLevel.Info, f"Organization '{org_name}' is deleted.")
+
         else:
             self.repo_service.update_repo_attrs(repo.id, deleting=True)
             for tag in repo.tags:
@@ -200,6 +215,24 @@ class RegistryService:
                 )
 
         return DeleteResponseDTO(message=f"Request to delete repository '{repo.canonical_name}' has been accepted and will be processed shortly.")
+
+    def delete_org(self, client: JobsClient, username: str, user_id: int, org_name: str) -> DeleteResponseDTO:
+        org = self.org_service.find_by_name(org_name)
+        org.deleting = True
+        name = org.name
+
+        if user_id != org.owner_id:
+            raise AccessDeniedException(f"User {username} cannot delete an organization with name {org_name}.")
+
+        if len(org.repositories) == 0:
+            self.org_service.remove_org(org)
+            self.event_service.log(EventLevel.Info, f"Organization '{name}' is deleted.")
+        else:
+            self.org_service.update_org_attrs(org.name, deleting=True)
+            for repo in org.repositories:
+                self.delete_repo(client, username, user_id, repo.id)
+
+        return DeleteResponseDTO(message=f"Request to delete organization '{name}' has been accepted and will be processed shortly.")
 
 def get_registry_service(session: Session = Depends(get_database)) -> RegistryService:
     return RegistryService(session)

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -205,7 +205,7 @@ class RegistryService:
         repo = self.repo_service.find_by_id(repo_id)
         name = repo.canonical_name
 
-        if not self.access_control_service.has_delete_access(user_id, repo_id):
+        if not self.access_control_service.has_delete_repo_access(user_id, repo):
             raise AccessDeniedException(f"User {username} cannot delete a repository with identifier {repo_id}.")
 
         self.repo_service.update_repo_attrs(repo.id, deleting=True)
@@ -221,7 +221,7 @@ class RegistryService:
                 )
 
         return DeleteResponseDTO(message=f"Request to delete repository '{name}' has been accepted and will be processed shortly.")
-
+    
     def delete_org(self, client: JobsClient, username: str, user_id: int, org_name: str) -> DeleteResponseDTO:
         org = self.org_service.find_by_name(org_name)
 

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -97,7 +97,7 @@ class RegistryService:
                 self.repo_service.remove_repo(repo)
                 self.event_service.log(EventLevel.Info, f"Repository '{repo_name}' is deleted.")
 
-                if org.deleting and len(org.repositories) == 0:
+                if org and org.deleting and len(org.repositories) == 0:
                     org_name = org.name
                     self.org_service.remove_org(org)
                     self.event_service.log(EventLevel.Info, f"Organization '{org_name}' is deleted.")
@@ -199,7 +199,7 @@ class RegistryService:
             self.repo_service.remove_repo(repo)
             self.event_service.log(EventLevel.Info, f"Repository '{name}' is deleted.")
 
-            if org.deleting and len(org.repositories) == 0:
+            if org and org.deleting and len(org.repositories) == 0:
                 org_name = org.name
                 self.org_service.remove_org(org)
                 self.event_service.log(EventLevel.Info, f"Organization '{org_name}' is deleted.")

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -91,7 +91,7 @@ class RegistryService:
     def _try_delete_repo_and_org(self, repo: Repository) -> bool:
         org = repo.organization
         delete_repo = repo.deleting and len(repo.tags) == 0
-        delete_org = delete_repo and org and org.deleting and len(org.repositories) == 0
+        delete_org = delete_repo and org and org.deleting and len(org.repositories) == 1
 
         if delete_repo:
             self._delete_repo(repo)

--- a/server/app/api/registry/registry_service.py
+++ b/server/app/api/registry/registry_service.py
@@ -19,6 +19,7 @@ from app.api.tags.tag_service import TagService
 from app.api.repo.repo_model import Repository
 from app.api.tags.tag_model import Tag
 from app.api.registry.registry_client import RegistryClient
+from app.api.org.org_model import Organization
 
 class RegistryService:
     def __init__(self, session: Session):
@@ -77,6 +78,29 @@ class RegistryService:
     
         return f"User '{username}' completed a {action} using method {method} on repo '{repo_name}' ({target}) [{desc}]"
 
+    def _delete_org(self, org: Organization) -> None:
+        org_name = org.name
+        self.org_service.remove_org(org)
+        self.event_service.log(EventLevel.Info, f"Organization '{org_name}' is deleted.")
+
+    def _delete_repo(self, repo: Repository) -> None:
+        repo_name = repo.canonical_name
+        self.repo_service.remove_repo(repo)
+        self.event_service.log(EventLevel.Info, f"Repository '{repo_name}' is deleted.")
+
+    def _try_delete_repo_and_org(self, repo: Repository) -> bool:
+        org = repo.organization
+        delete_repo = repo.deleting and len(repo.tags) == 0
+        delete_org = delete_repo and org and org.deleting and len(org.repositories) == 0
+
+        if delete_repo:
+            self._delete_repo(repo)
+
+        if delete_org:
+            self._delete_org(org)
+
+        return delete_repo or delete_org
+
     def on_notification(self, username: str, action: str, repo_name: str, tag_name: str | None, digest: str, method: str, url: str | None):
 
         if action == 'push' and tag_name is not None:
@@ -91,16 +115,7 @@ class RegistryService:
             self.tag_service.remove_tag(tag.id)
             self.event_service.log(EventLevel.Info, f"Tag '{tag_name}' of repository '{repo.canonical_name}' is deleted.")
 
-            if repo.deleting and len(repo.tags) == 0:
-                org = repo.organization
-                repo_name = repo.canonical_name
-                self.repo_service.remove_repo(repo)
-                self.event_service.log(EventLevel.Info, f"Repository '{repo_name}' is deleted.")
-
-                if org and org.deleting and len(org.repositories) == 0:
-                    org_name = org.name
-                    self.org_service.remove_org(org)
-                    self.event_service.log(EventLevel.Info, f"Organization '{org_name}' is deleted.")
+            self._try_delete_repo_and_org(repo)
 
         message = self._format_registry_event(username, action, repo_name, tag_name, digest, method, url)
         print(message)
@@ -152,8 +167,7 @@ class RegistryService:
         # Create the JWT.
         jwt = build_jwt_for_docker_registry(username, service, scopes)
         return {"token": jwt}
-    
-   
+     
     async def _fetch_manifest_digest(self, client: RegistryClient, repo_name: str, tag_name: str, username: str) -> str | None:
 
         jwt = build_manifest_jwt(username, repo_name, "GET")
@@ -194,18 +208,10 @@ class RegistryService:
         if not self.access_control_service.has_delete_access(user_id, repo_id):
             raise AccessDeniedException(f"User {username} cannot delete a repository with identifier {repo_id}.")
 
-        if len(repo.tags) == 0:
-            org = repo.organization
-            self.repo_service.remove_repo(repo)
-            self.event_service.log(EventLevel.Info, f"Repository '{name}' is deleted.")
-
-            if org and org.deleting and len(org.repositories) == 0:
-                org_name = org.name
-                self.org_service.remove_org(org)
-                self.event_service.log(EventLevel.Info, f"Organization '{org_name}' is deleted.")
-
-        else:
-            self.repo_service.update_repo_attrs(repo.id, deleting=True)
+        self.repo_service.update_repo_attrs(repo.id, deleting=True)
+        deleted = self._try_delete_repo_and_org(repo)
+        
+        if deleted is False:
             for tag in repo.tags:
                 queue = client.get("delete_tag")
                 queue.enqueue(
@@ -218,21 +224,19 @@ class RegistryService:
 
     def delete_org(self, client: JobsClient, username: str, user_id: int, org_name: str) -> DeleteResponseDTO:
         org = self.org_service.find_by_name(org_name)
-        org.deleting = True
-        name = org.name
 
         if user_id != org.owner_id:
             raise AccessDeniedException(f"User {username} cannot delete an organization with name {org_name}.")
 
+        self.org_service.update_org_attrs(org.name, deleting=True)
+
         if len(org.repositories) == 0:
-            self.org_service.remove_org(org)
-            self.event_service.log(EventLevel.Info, f"Organization '{name}' is deleted.")
+            self._delete_org(org)
         else:
-            self.org_service.update_org_attrs(org.name, deleting=True)
             for repo in org.repositories:
                 self.delete_repo(client, username, user_id, repo.id)
 
-        return DeleteResponseDTO(message=f"Request to delete organization '{name}' has been accepted and will be processed shortly.")
+        return DeleteResponseDTO(message=f"Request to delete organization '{org_name}' has been accepted and will be processed shortly.")
 
 def get_registry_service(session: Session = Depends(get_database)) -> RegistryService:
     return RegistryService(session)

--- a/server/app/api/team/team_model.py
+++ b/server/app/api/team/team_model.py
@@ -15,13 +15,13 @@ class TeamPermissionKind(str, enum.Enum):
 
 class TeamMember(SQLModel, table=True):
     user_id: int | None = Field(default=None, foreign_key="user.id", primary_key=True)
-    team_id: int | None = Field(default=None, foreign_key="team.id", primary_key=True)
+    team_id: int | None = Field(default=None, foreign_key="team.id", primary_key=True, ondelete="CASCADE")
 
     team: "Team" = Relationship(back_populates="members")
     user: "User" = Relationship()
 
 class TeamPermission(SQLModel, table=True):
-    team_id: int | None = Field(default=None, foreign_key="team.id", primary_key=True)
+    team_id: int | None = Field(default=None, foreign_key="team.id", primary_key=True, ondelete="CASCADE")
     repo_id: int | None = Field(default=None, foreign_key="repository.id", primary_key=True, ondelete="CASCADE")
 
     kind: TeamPermissionKind = Field(default=TeamPermissionKind.read)
@@ -34,8 +34,8 @@ class Team(SQLModel, table=True):
     name: str = Field()
     desc: str = Field()
 
-    organization_id: Optional[int] = Field(default=None, foreign_key="organization.id")
+    organization_id: Optional[int] = Field(default=None, foreign_key="organization.id", ondelete="CASCADE")
     organization: "Organization" = Relationship()
 
-    members: List["TeamMember"] = Relationship(back_populates="team")
-    permissions : List["TeamPermission"] = Relationship(back_populates="team")
+    members: List["TeamMember"] = Relationship(back_populates="team", cascade_delete=True)
+    permissions : List["TeamPermission"] = Relationship(back_populates="team", cascade_delete=True)

--- a/server/app/tests/test_organization.py
+++ b/server/app/tests/test_organization.py
@@ -1,9 +1,9 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 from fastapi.testclient import TestClient
 import pytest
 from app.api.org.org_service import OrganizationService
 from app.api.org.org_dto import OrganizationCreateDTO
-from app.api.config.exception_handler import FieldTakenException
+from app.api.config.exception_handler import FieldTakenException, NotFoundException
 from app.api.config.exception_handler import FieldTakenException
 from app.api.main import app
 from app.api.repo.repo_model import Repository
@@ -175,3 +175,73 @@ class TestGetOrgNamesFromRepos:
         assert result[o1.id] == o1.name
         assert result[o2.id] == o2.name
         org_service.org_repo.find_orgs_by_ids.assert_called_once_with(ids)
+
+class TestUpdateOrgAttrs():
+        
+    def test_org_not_exist(self, org_service):
+        """ Test case for when the org does not exist. """
+        org_name = "o1"
+        org_service.org_repo.find_by_name.return_value = None
+
+        with pytest.raises(NotFoundException):
+            org_service.update_org_attrs(org_name, desc="desc123")
+        
+        org_service.org_repo.find_by_name.assert_called_once_with(org_name)
+
+    def test_attributes_not_passed(self, org_service):
+        """ Test case for when no attributes are passed. """ 
+        org = MagicMock(spec=Organization)
+        org.id = 1
+        org.name = "o1"
+        org.desc = "desc"
+        org_service.org_repo.find_by_name.return_value = org
+
+        result = org_service.update_org_attrs(org.name)
+
+        assert result == org 
+        assert result.id == org.id
+        assert result.name == org.name
+        assert result.desc == org.desc
+        org_service.org_repo.find_by_name.assert_called_once_with(org.name)
+
+    def test_attribute_not_exist(self, org_service):
+        """ Test case for when a specified attribute does not exist. """  
+        org = MagicMock(spec=Organization)
+        org.id = 1
+        org.name = "o1"
+        org.desc = "desc"
+        org_service.org_repo.find_by_name.return_value = org
+        org_service.org_repo.set_attribute.side_effect = ValueError("unknown attribute")
+
+        with pytest.raises(ValueError) as e: 
+            org_service.update_org_attrs(org.name, unknown_attr="fail")
+        
+        assert "unknown attribute" in str(e.value)
+        org_service.org_repo.find_by_name.assert_called_once_with(org.name)
+        org_service.org_repo.set_attribute.assert_called_once_with(org, "unknown_attr", "fail")
+    
+    def test_successfully_update_attributes(self, org_service):
+        """ Test case for when the attributes exist. """
+        org = MagicMock(spec=Organization)
+        org.id = 1
+        org.desc = "desc"
+        org.deleting = False
+        org_service.org_repo.find_by_name.return_value = org
+
+        def mock_set_attribute(org, attr, value):
+            setattr(org, attr, value)
+            return org
+        org_service.org_repo.set_attribute.side_effect = mock_set_attribute
+
+        result = org_service.update_org_attrs(name=org.name, deleting=True, desc="new_desc")
+
+        assert result.id == 1
+        assert result.deleting == True
+        assert result.desc == "new_desc"
+        org_service.org_repo.find_by_name.assert_called_once_with(org.name)
+        expected_calls = [
+            call(org, "deleting", True), 
+            call(org, "desc", "new_desc"), 
+        ]
+        assert org_service.org_repo.set_attribute.call_args_list == expected_calls
+    

--- a/server/app/tests/test_organization.py
+++ b/server/app/tests/test_organization.py
@@ -244,4 +244,26 @@ class TestUpdateOrgAttrs():
             call(org, "desc", "new_desc"), 
         ]
         assert org_service.org_repo.set_attribute.call_args_list == expected_calls
-    
+
+class TestFindByName:
+
+    def test_org_not_exist(self, org_service):
+        """ Test case for when the org does not exist. """
+        org_name = "o999"
+        org_service.org_repo.find_by_name.return_value = None
+
+        with pytest.raises(NotFoundException): 
+            org_service.find_by_name(org_name)
+
+        org_service.org_repo.find_by_name.assert_called_once_with(org_name)
+
+    def test_org_exist(self, org_service):
+        """ Test case for when the org exists. """
+        org = MagicMock(spec=Organization)
+        org.name = "o1"
+        org_service.org_repo.find_by_name.return_value = org
+
+        result = org_service.find_by_name(org.name)
+
+        org_service.org_repo.find_by_name.assert_called_once_with(org.name)
+        assert result == org

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -598,13 +598,13 @@ class TestDeleteRepo:
         registry_service.repo_service.find_by_id.return_value = repo
         user_id = 1
         repo.id = 1
-        registry_service.access_control_service.has_delete_access.return_value = False
+        registry_service.access_control_service.has_delete_repo_access.return_value = False
 
         with pytest.raises(AccessDeniedException): 
             registry_service.delete_repo(client, "user", user_id, repo.id)
     
         registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
-        registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
+        registry_service.access_control_service.has_delete_repo_access.assert_called_once_with(user_id, repo)
         
     def test_repo_not_have_tags(self, registry_service: RegistryService):
         """ Test case for when the repository does not have any tags. """
@@ -625,7 +625,7 @@ class TestDeleteRepo:
 
         assert isinstance(result, DeleteResponseDTO)
         registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
-        registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
+        registry_service.access_control_service.has_delete_repo_access.assert_called_once_with(user_id, repo)
         registry_service.repo_service.remove_repo.assert_called_once_with(repo)
         registry_service.event_service.log.assert_called_once_with(EventLevel.Info, f"Repository '{repo.canonical_name}' is deleted.")
 
@@ -655,7 +655,7 @@ class TestDeleteRepo:
         assert queue.enqueue.call_count == 2
         client.get.assert_called_with("delete_tag")
         registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
-        registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
+        registry_service.access_control_service.has_delete_repo_access.assert_called_once_with(user_id, repo)
         registry_service.repo_service.update_repo_attrs.assert_called_once_with(repo.id, deleting=True)
 
     @patch("app.api.jobs.jobs_client.JobsClient.get", return_value=MagicMock())
@@ -745,8 +745,6 @@ class TestDeleteRepo:
                 tag_service = TagService(session)
                 return tag_service.on_push(user_id, repo_id, tag_name).model_dump()
             
-            
-
             def delete_repo(repo_id, username):
                 header = {"Authorization": f"Bearer {log_in(username)}"}
                 return client.request("DELETE", f"/api/v1/registry/repository/{repo_id}", headers=header)
@@ -877,7 +875,7 @@ class TestDeleteOrg:
         registry_service.org_service.remove_org.assert_not_called()
         registry_service.event_service.log.assert_not_called()
         registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
-        registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
+        registry_service.access_control_service.has_delete_repo_access.assert_called_once_with(user_id, repo)
         client.get.assert_called_once_with("delete_tag")
         assert result.message == f"Request to delete organization '{org.name}' has been accepted and will be processed shortly."
 

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -879,6 +879,86 @@ class TestDeleteOrg:
         client.get.assert_called_once_with("delete_tag")
         assert result.message == f"Request to delete organization '{org.name}' has been accepted and will be processed shortly."
 
+    @patch("app.api.jobs.jobs_client.JobsClient.get", return_value=MagicMock())
+    def test_delete_org__integration(self, mock_get_queue):
+
+        # NOTE: Queues are mocked in these tests, as  
+        # spinning up Redis and workers is very complex.
+
+        with TestClient(app) as client:
+            def add_user(username):
+                data = {
+                    "username": username,
+                    "email": f"{username}@email.com",
+                    "password": "1234"
+                }
+                response = client.post("/api/v1/users/", json=data)
+                return response.json()
+
+            def log_in(username):
+                data = {"username": username, "password": "1234"}
+                response = client.post("/api/v1/users/login", json=data)
+                return response.json()["token"]
+
+            def add_repo(username, repo_name, org_id = None):
+                data = {
+                    "name": repo_name,
+                    "desc": "",
+                    "public": True,
+                    "organization_id": org_id,
+                }
+                header = {"Authorization": f"Bearer {log_in(username)}"}
+
+                return client.post("/api/v1/repositories/", json=data, headers=header).json()
+            
+            def add_org(username, name: str) -> dict:
+                jwt = log_in(username)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+                dto = {
+                    "name": name,
+                    "desc": "",
+                    "image": None
+                }
+                return client.post("/api/v1/organizations", json=dto, headers=header).json()
+
+            def add_tag(user_id, repo_id, tag_name):
+                session = next(get_database())
+                tag_service = TagService(session)
+                return tag_service.on_push(user_id, repo_id, tag_name).model_dump()
+            
+            def delete_org(org_name, username):
+                header = {"Authorization": f"Bearer {log_in(username)}"}
+                return client.request("DELETE", f"/api/v1/registry/organization/{org_name}", headers=header)
+
+            u1 = add_user("u1")
+            u2 = add_user("u2")
+            o1 = add_org("u1", "o1")
+            o2 = add_org("u1", "o2")
+            r1 = add_repo("u1", "r1", o1["id"])
+            r2 = add_repo("u1", "r2", o1["id"])
+            r3 = add_repo("u1", "r2", o1["id"])
+            add_tag(u1["id"], r1["id"], "t1")
+            add_tag(u1["id"], r1["id"], "t2")
+            add_tag(u1["id"], r2["id"], "t3")
+
+            # 1) User is not organization owner.
+            response = delete_org(o1["name"], u2["username"])
+            assert response.status_code == 400
+            assert mock_get_queue.call_count == 0
+
+            # 2) User is organization owner, whereas organization is empty.
+            with patch("app.api.events.event_service.EventService.log"):
+                response = delete_org(o2["name"], u1["username"])
+                assert response.status_code == 202
+                assert mock_get_queue.call_count == 0
+
+            # 3) User is organization owner, whereas organization has repositories.
+            with patch("app.api.events.event_service.EventService.log"):
+                response = delete_org(o1["name"], u1["username"])
+                assert response.status_code == 202
+                assert mock_get_queue.call_count == 3
+
 class TestOnNotification:
     
     # NOTE: Most cases that do not require deeper logic in `on_notification`

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -26,6 +26,7 @@ from app.api.config.database import get_database
 from app.api.tags.tag_service import TagService
 from app.api.team.team_model import TeamMember, TeamPermissionKind, TeamPermission
 from app.api.org.org_model import Organization, OrganizationMembers
+from app.api.org.org_service import OrganizationService
 
 BUILD_MANIFEST_JWT_PATH = "app.api.registry.registry_service.build_manifest_jwt"
 
@@ -39,6 +40,7 @@ def registry_service() -> RegistryService:
     service.access_control_service = MagicMock(AccessControlService)
     service.tag_service = MagicMock(TagService)
     service.event_service = MagicMock(EventService)
+    service.org_service = MagicMock(OrganizationService)
 
     return service
 
@@ -797,6 +799,87 @@ class TestDeleteRepo:
             response = delete_repo(r4["id"], u3["username"])
             assert response.status_code == 202
             assert mock_get_queue.call_count == 4   
+
+class TestDeleteOrg:
+    
+    def test_org_not_exist(self, registry_service: RegistryService):
+        """ Test case for when the organization does not exist. """
+        client = MagicMock(spec=JobsClient)
+        user_id = 1
+        org_name = "o1"
+        registry_service.org_service.find_by_name.side_effect = NotFoundException(Organization, org_name)
+
+        with pytest.raises(NotFoundException): 
+            registry_service.delete_org(client, "user", user_id, org_name)
+    
+        registry_service.org_service.find_by_name.assert_called_once_with(org_name)
+        registry_service.org_service.update_org_attrs.assert_not_called()
+
+    def test_user_not_have_permission(self, registry_service: RegistryService):
+        """ Test case for when the user does not have permission. """
+        client = MagicMock(spec=JobsClient)
+        user_id = 9999
+        org = MagicMock(spec=Organization)
+        org.name = "o1"
+        org.owner_id = 1
+        registry_service.org_service.find_by_name.return_value = org
+
+        with pytest.raises(AccessDeniedException): 
+            registry_service.delete_org(client, "user", user_id, org.name)
+    
+        registry_service.org_service.find_by_name.assert_called_once_with(org.name)
+        registry_service.org_service.update_org_attrs.assert_not_called()
+
+    def test_org_not_have_repos(self, registry_service: RegistryService):
+        """ Test case for when the org does not have any repo. """
+        client = MagicMock(spec=JobsClient)
+        user_id = 1
+        org = MagicMock(spec=Organization)
+        org.name = "o1"
+        org.owner_id = 1
+        org.repositories = []
+        registry_service.org_service.find_by_name.return_value = org
+
+        result = registry_service.delete_org(client, "user", user_id, org.name)
+    
+        registry_service.org_service.find_by_name.assert_called_once_with(org.name)
+        registry_service.org_service.update_org_attrs.assert_called_once_with(org.name, deleting=True)
+        registry_service.org_service.remove_org.assert_called_once_with(org)
+        registry_service.event_service.log.assert_called_once()
+        assert result.message == f"Request to delete organization '{org.name}' has been accepted and will be processed shortly."
+
+    def test_org_have_repos(self, registry_service: RegistryService):
+        """ Test case for when the org has repos. """
+        
+        # I won't test the deeper logic behind `self.delete_repo`, 
+        # as we have unit tests specifically designed for it.
+
+        client = MagicMock(spec=JobsClient)
+        user_id = 1
+        tag = MagicMock(speci=Tag)
+        repo = MagicMock(spec=Repository)
+        repo.id = 1
+        repo.deleting = False
+        repo.tags = [tag]
+        org = MagicMock(spec=Organization)
+        org.name = "o1"
+        org.owner_id = 1
+        org.repositories = [repo]
+        org.deleting = False
+        repo.organization = org
+        registry_service.org_service.find_by_name.return_value = org
+        registry_service.repo_service.find_by_id.return_value = repo
+
+        result = registry_service.delete_org(client, "user", user_id, org.name)
+    
+        registry_service.org_service.find_by_name.assert_called_once_with(org.name)
+        registry_service.org_service.update_org_attrs.assert_called_once_with(org.name, deleting=True)
+        registry_service.org_service.remove_org.assert_not_called()
+        registry_service.event_service.log.assert_not_called()
+        registry_service.repo_service.find_by_id.assert_called_once_with(repo.id)
+        registry_service.access_control_service.has_delete_access.assert_called_once_with(user_id, repo.id)
+        client.get.assert_called_once_with("delete_tag")
+        assert result.message == f"Request to delete organization '{org.name}' has been accepted and will be processed shortly."
 
 # -----------------------------------
 # Util functions

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -25,7 +25,7 @@ from httpx import AsyncClient, Response, Request
 from app.api.config.database import get_database
 from app.api.tags.tag_service import TagService
 from app.api.team.team_model import TeamMember, TeamPermissionKind, TeamPermission
-from app.api.org.org_model import OrganizationMembers
+from app.api.org.org_model import Organization, OrganizationMembers
 
 BUILD_MANIFEST_JWT_PATH = "app.api.registry.registry_service.build_manifest_jwt"
 
@@ -614,6 +614,8 @@ class TestDeleteRepo:
         repo.owner = MagicMock(spec=User)
         repo.owner.username = "user"
         repo.tags = []
+        repo.organization = MagicMock(spec=Organization)
+        repo.organization.deleting = False
         registry_service.repo_service.find_by_id.return_value = repo
         registry_service.repo_service.remove_repo.return_value = None
 

--- a/server/app/tests/test_registry.py
+++ b/server/app/tests/test_registry.py
@@ -881,6 +881,91 @@ class TestDeleteOrg:
         client.get.assert_called_once_with("delete_tag")
         assert result.message == f"Request to delete organization '{org.name}' has been accepted and will be processed shortly."
 
+class TestOnNotification:
+    
+    # NOTE: Most cases that do not require deeper logic in `on_notification`
+    # are covered by tests for `_format_registry_event`.
+
+    def test_push_operation(self, registry_service: RegistryService):
+        """ Test case for the push tag operation. """
+        user = MagicMock(spec=User)
+        user.id = 1
+        user.username = "user"
+
+        repo = MagicMock(spec=Repository)
+        repo.id = 1
+        repo.canonical_name="repo"
+
+        action="push"
+        tag_name="tag"
+        digest="sha:123"
+        method="PUT"
+        url="/v2/repo/manifests/sha:123"
+
+        registry_service.user_service.find_by_username.return_value = user
+        registry_service.repo_service.find_by_canonical_name.return_value = repo
+
+        registry_service.on_notification(user.username, action, repo.canonical_name, tag_name, digest, method, url)
+    
+        registry_service.user_service.find_by_username.assert_called_once_with(user.username)
+        registry_service.repo_service.find_by_canonical_name.assert_called_once_with(repo.canonical_name)
+        registry_service.tag_service.on_push.assert_called_once_with(user.id, repo.id, tag_name)
+        registry_service.event_service.log.assert_called_once_with(EventLevel.Info, f"Tag '{tag_name}' of repository '{repo.canonical_name}' is pushed.")
+
+    def test_delete_operation(self, registry_service: RegistryService):
+        """ Test case for the delete tag operation. """
+        user = MagicMock(spec=User)
+        user.id = 1
+        user.username = "user"
+
+        org = MagicMock(spec=Organization)
+        org.deleting = False
+
+        repo = MagicMock(spec=Repository)
+        repo.id = 1
+        repo.canonical_name="repo"
+        repo.deleting = False
+        repo.organization = org
+
+        tag = MagicMock(spec=Tag)
+        tag.name = "tag"
+
+        action="delete"
+        digest="sha:123"
+        method="DELETE"
+        url="/v2/repo/manifests/sha:123"
+
+        registry_service.repo_service.find_by_canonical_name.return_value = repo
+        registry_service.tag_service.find_by_name_and_repo_id.return_value = tag
+
+        registry_service.on_notification(user.username, action, repo.canonical_name, tag.name, digest, method, url)
+    
+        registry_service.repo_service.find_by_canonical_name.assert_called_once_with(repo.canonical_name)
+        registry_service.tag_service.find_by_name_and_repo_id.assert_called_once_with(tag.name, repo.id)
+        registry_service.tag_service.remove_tag.assert_called_once_with(tag.id)
+        registry_service.event_service.log.assert_called_once_with(EventLevel.Info, f"Tag '{tag.name}' of repository '{repo.canonical_name}' is deleted.")
+
+    def test_uncovered_operation(self, registry_service: RegistryService):
+        """ Test case for the uncovered operation. """
+        user = MagicMock(spec=User)
+        user.id = 1
+        user.username = "user"
+
+        repo = MagicMock(spec=Repository)
+        repo.id = 1
+        repo.canonical_name="repo"
+
+        action="unknown"
+        digest="sha:123"
+        method="POST"
+        url="/v2/repo/..."
+        tag_name=None
+
+        with pytest.raises(ValueError) as e:
+            registry_service.on_notification(user.username, action, repo.canonical_name, tag_name, digest, method, url)
+            
+        assert str(e.value) == f"Unsupported event: action='{action}', repo='{repo.canonical_name}', tag='{tag_name}', method='{method}', url='{url}'"
+
 # -----------------------------------
 # Util functions
 # -----------------------------------


### PR DESCRIPTION
Closes #46.

This is a relatively simple feature that reuses already implemented functionalities, such as `delete_repo` and consequently `delete_org`.

Cascade deletion is leveraged, relying on existing `backend` behavior.

Tests are also written for the old function `on_notification`. Fixes and refactoring are a significant portion of this PR.