### PR TITLE
Feature update organization description

### DIFF
--- a/client/src/api/org.api.ts
+++ b/client/src/api/org.api.ts
@@ -36,6 +36,10 @@ export interface DeleteOrgResponseDTO {
     message: string
 }
 
+export interface OrgDescUpdateDTO {
+    desc: string
+}
+
 export class OrganizationService {
     static async CreateOrganization(dto: OrganizationCreateDTO): Promise<AxiosResponse<OrganizationDTOBasic>> {
         return await axiosInstance.post(`/organizations`, dto);
@@ -60,4 +64,9 @@ export class OrganizationService {
     static async DeleteOrg(orgName: string) : Promise<AxiosResponse<DeleteOrgResponseDTO>> {
         return await axiosInstance.delete(`/registry/organization/${orgName}`)
     }
+
+    static async UpdateOrgDescByName(orgName: string, dto: OrgDescUpdateDTO) : Promise<AxiosResponse<OrganizationDTOBasic>> {
+        return await axiosInstance.put(`/organizations/${orgName}/desc`, dto)
+    }
 }
+

--- a/client/src/components/OrgOverview.tsx
+++ b/client/src/components/OrgOverview.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { RepoExtDTO, RepositoryService } from '../api/repo.api';
+import { RepositoryDescUpdateDTO } from '../api/repo.api';
+import { ToastType, useToastStore } from '../util/toastStore';
+import { Alert, Card } from 'react-bootstrap';
+import { AxiosError } from 'axios';
+import { OrganizationDTOBasic, OrganizationService, OrgDescUpdateDTO } from '../api/org.api';
+import { getJwtId } from '../util/localstorage';
+
+export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasic, setOrg: any }> = (props) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [newDesc, setNewDesc] = useState(props.org.desc);
+    const addToast = useToastStore((state) => state.addToast);
+    const [error, setError] = useState('');
+    const [amOwnerOfOrg, setAmOwnerOfOrg] = useState(false);
+    
+    const checkIfIamOwnerOfOrg = () => {
+        if (getJwtId() === props.org.owner_id) {
+            setAmOwnerOfOrg(true);
+        }
+    }
+    
+    useEffect(() => {
+        if (props.isActive) {
+            checkIfIamOwnerOfOrg();
+        }
+    }, [props.isActive]);
+
+    const updateChanges = () => {
+        setIsEditing(false);
+
+        let dto: OrgDescUpdateDTO = {
+            desc: newDesc,
+        };
+        
+        OrganizationService.UpdateOrgDescByName(props.org.name, dto).then((res) => {
+            props.setOrg({
+                ...props.org,
+                ...res.data,
+            });
+            addToast(`Updated the description of ${props.org.name}.`, ToastType.success);
+            setError('');
+        }).catch((err: AxiosError) => {
+            setError((err.response?.data as any)["detail"]["message"]);
+        });
+    };
+
+    return (
+        <>
+            {/* Consider placing the image next to the organization name */}
+            <img src={OrganizationService.GetImageURI(props.org.image)} /> <br /> 
+
+            <div className="tab-pane fade show active" id="overview">
+                {error && <Alert variant="danger">{error}</Alert>}
+                {isEditing ? (
+                    <div>
+                        <textarea className="form-control" rows={7} value={newDesc} onChange={(e) => setNewDesc(e.target.value)}/>
+                        <div className='mt-3'>
+                            <button className="btn btn-primary me-2" onClick={updateChanges}> 
+                                Update 
+                            </button>
+                            <button className="btn btn-secondary" onClick={() => { setIsEditing(false); setNewDesc(props.org.desc); }}> 
+                                Cancel 
+                            </button>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="d-flex align-items-center">
+                        <div className='repo-page-desc'>{props.org.desc}</div>
+                        {amOwnerOfOrg && (
+                            <button className="btn btn-link p-0 ms-2" onClick={() => setIsEditing(true)}>
+                                <i className="bi bi-pencil"></i>
+                            </button>
+                        )}
+                    </div>
+                )}
+            </div>
+        </>
+    );
+};

--- a/client/src/components/OrgOverview.tsx
+++ b/client/src/components/OrgOverview.tsx
@@ -26,7 +26,7 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
         }
     }, [props.isActive]);
 
-    const updateChanges = () => {
+    const updateDescription = () => {
         setIsEditing(false);
 
         let dto: OrgDescUpdateDTO = {
@@ -56,8 +56,8 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
                     <div>
                         <textarea className="form-control" rows={7} value={newDesc} onChange={(e) => setNewDesc(e.target.value)}/>
                         <div className='mt-3'>
-                            <button className="btn btn-primary me-2" onClick={updateChanges}> 
-                                Update 
+                            <button className="btn btn-primary me-2" onClick={updateDescription}> 
+                                Update description
                             </button>
                             <button className="btn btn-secondary" onClick={() => { setIsEditing(false); setNewDesc(props.org.desc); }}> 
                                 Cancel 

--- a/client/src/components/OrgOverview.tsx
+++ b/client/src/components/OrgOverview.tsx
@@ -48,7 +48,7 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
     return (
         <>
             {/* Consider placing the image next to the organization name */}
-            <img src={OrganizationService.GetImageURI(props.org.image)} /> <br /> 
+            <img src={OrganizationService.GetImageURI(props.org.image)} className="mb-3"/> 
 
             <div className="tab-pane fade show active" id="overview">
                 {error && <Alert variant="danger">{error}</Alert>}

--- a/client/src/components/OrgOverview.tsx
+++ b/client/src/components/OrgOverview.tsx
@@ -54,7 +54,7 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
                 {error && <Alert variant="danger">{error}</Alert>}
                 {isEditing ? (
                     <div>
-                        <textarea className="form-control" rows={7} value={newDesc} onChange={(e) => setNewDesc(e.target.value)}/>
+                        <textarea className="form-control" rows={7} value={newDesc} onChange={(e) => setNewDesc(e.target.value)} autoFocus/>
                         <div className='mt-3'>
                             <button className="btn btn-primary me-2" onClick={updateDescription}> 
                                 Update description

--- a/client/src/components/OrgSettings.tsx
+++ b/client/src/components/OrgSettings.tsx
@@ -45,13 +45,6 @@ export const OrgSettings: React.FC<{ isActive: boolean, org: OrganizationDTOBasi
     
     return (
         <>
-            <Card className="mt-4">
-                <Card.Body>
-                    <img src={OrganizationService.GetImageURI(org.image)} /> <br />
-                    Desc: {org.desc} <br />
-                </Card.Body>
-            </Card>
-
             {amOwnerOfOrg && 
                 <Card className="mt-4">
                     <Card.Body>

--- a/client/src/components/RepoOverview.tsx
+++ b/client/src/components/RepoOverview.tsx
@@ -17,7 +17,7 @@ export const RepoOverview: React.FC<{ isActive: boolean; repo: RepoExtDTO, setRe
         }
     }, [props.isActive]);
 
-    const updateChanges = () => {
+    const updateDescription = () => {
         setIsEditing(false);
 
         let dto: RepositoryDescUpdateDTO = {
@@ -43,8 +43,8 @@ export const RepoOverview: React.FC<{ isActive: boolean; repo: RepoExtDTO, setRe
                 <div>
                     <textarea className="form-control" rows={7} value={newDesc} onChange={(e) => setNewDesc(e.target.value)}/>
                     <div className='mt-3'>
-                        <button className="btn btn-primary me-2" onClick={updateChanges}> 
-                            Update 
+                        <button className="btn btn-primary me-2" onClick={updateDescription}> 
+                            Update description
                         </button>
                         <button className="btn btn-secondary" onClick={() => { setIsEditing(false); setNewDesc(props.repo.desc); }}> 
                             Cancel 

--- a/client/src/components/RepoOverview.tsx
+++ b/client/src/components/RepoOverview.tsx
@@ -41,7 +41,7 @@ export const RepoOverview: React.FC<{ isActive: boolean; repo: RepoExtDTO, setRe
             {error && <Alert variant="danger">{error}</Alert>}
             {isEditing ? (
                 <div>
-                    <textarea className="form-control" rows={7} value={newDesc} onChange={(e) => setNewDesc(e.target.value)}/>
+                    <textarea className="form-control" rows={7} value={newDesc} onChange={(e) => setNewDesc(e.target.value)} autoFocus/>
                     <div className='mt-3'>
                         <button className="btn btn-primary me-2" onClick={updateDescription}> 
                             Update description

--- a/client/src/pages/OrgPage.tsx
+++ b/client/src/pages/OrgPage.tsx
@@ -8,12 +8,13 @@ import { OrgMembers } from "../components/OrgMembers";
 import { OrgRepositories } from "../components/OrgRepositories";
 import { OrgTeams } from "../components/OrgTeams";
 import { OrgSettings } from "../components/OrgSettings";
+import { OrgOverview } from "../components/OrgOverview";
 
 export const OrganizationPage = () => {
     const { "*": orgName } = useParams();
     const [loading, setLoading] = useState<boolean>(true);
     const [org, setOrg] = useState<OrganizationDTOBasic>();
-    const [key, setKey] = useState<string>('members');
+    const [key, setKey] = useState<string>('overview');
     const [amMemberOfOrg, setAmMemberOfOrg] = useState<boolean>(false);
     let navigate = useNavigate();
 
@@ -60,6 +61,7 @@ export const OrganizationPage = () => {
             <div className="org-page">
                 {/* Organization Section */}
                 <div className="org-page-header mb-4">
+                    
                     <h1>
                         {org?.name}
                     </h1>
@@ -68,6 +70,12 @@ export const OrganizationPage = () => {
                 {/* Tabs Section */}
                 <Tab.Container activeKey={key} onSelect={(k) => setKey(k!)} id="tabs">
                     <Nav variant="tabs" className="mb-3">
+                        <Nav.Item>
+                            <Nav.Link eventKey="overview" className={key === 'overview' ? 'active' : ''}>
+                                <i className="bi bi-list"> </i>
+                                Overview
+                            </Nav.Link>
+                        </Nav.Item>
                         <Nav.Item>
                             <Nav.Link eventKey="members" className={key === 'members' ? 'active' : ''}>
                                 <i className="bi bi-person"> </i>
@@ -95,6 +103,9 @@ export const OrganizationPage = () => {
                     </Nav>
 
                     <Tab.Content>
+                        <Tab.Pane eventKey="overview">
+                            <OrgOverview isActive={key === 'overview'} org={org} setOrg={setOrg} />
+                        </Tab.Pane>
                         <Tab.Pane eventKey="members">
                             <OrgMembers isActive={key === 'members'} />
                         </Tab.Pane>

--- a/compose.yaml
+++ b/compose.yaml
@@ -85,6 +85,8 @@ services:
       - "80:80"
     depends_on:
       - backend
+    volumes:
+      - ./images:/usr/share/nginx/html/images/
   
   cache:
     image: redis:alpine3.20

--- a/server/app/api/org/org_controller.py
+++ b/server/app/api/org/org_controller.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter, Depends
 from app.api.config.auth import get_id_from_jwt, get_id_from_jwt_optional, pre_authorize
 from app.api.user.user_model import UserRole
 from app.api.config.auth import JWTDep, JWTDepOptional
-from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDTO, OrganizationDTOBasic, OrganizationHasMemberDTO
+from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDTO, OrganizationDTOBasic, OrganizationDescUpdateDTO, OrganizationHasMemberDTO
 from app.api.org.org_service import OrganizationService, get_org_service
+from app.api.access_control.access_control_service import AccessControlService
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
 
@@ -37,3 +38,13 @@ def am_i_member_of_org(org_id: int, jwt: JWTDepOptional, org_service: Organizati
         user_id=user_id, 
         is_member=is_member
     )
+
+@router.put("/{org_name}/desc", response_model=OrganizationDTO, status_code=200, summary="Update organization description by its name")
+@pre_authorize([UserRole.user, UserRole.admin])
+def update_org_desc_by_name(
+    jwt: JWTDep, org_name: str, 
+    dto: OrganizationDescUpdateDTO, 
+    org_service: OrganizationService = Depends(get_org_service)):
+    user_id = get_id_from_jwt(jwt)
+    org = org_service.update_desc_by_name(org_name, dto, user_id)
+    return org

--- a/server/app/api/org/org_dto.py
+++ b/server/app/api/org/org_dto.py
@@ -31,3 +31,6 @@ class OrganizationHasMemberDTO(BaseModel):
     org_id: int
     user_id: int | None
     is_member: bool
+
+class OrganizationDescUpdateDTO(BaseModel):
+    desc: str

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -2,10 +2,10 @@ from typing import Dict, List
 from fastapi import Depends
 from sqlmodel import Session
 from app.api.config.database import get_database
-from app.api.org.org_dto import OrganizationCreateDTO
+from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDescUpdateDTO
 from app.api.org.org_model import Organization, OrganizationMembers
 from app.api.org.org_repo import OrganizationRepo
-from app.api.config.exception_handler import FieldTakenException, NotFoundException
+from app.api.config.exception_handler import AccessDeniedException, FieldTakenException, NotFoundException
 from app.api.config.images import generate_inline_image, save_image
 from app.api.repo.repo_model import Repository
  
@@ -91,6 +91,13 @@ class OrganizationService:
 
     def remove_org(self, org: Organization) -> None:
         self.org_repo.remove(org)
+
+    def update_desc_by_name(self, name: str, dto: OrganizationDescUpdateDTO, user_id: int) -> Organization:
+        org = self.find_by_name(name)
+        if user_id != org.owner.id:
+            raise AccessDeniedException(f"User {user_id} cannot update organization description with identifier {name}")
+        self.update_org_attrs(name, desc=dto.desc)
+        return org
 
     def update_org_attrs(self, name: str, **kwargs) -> Organization:
         org = self.find_by_name(name)

--- a/server/app/tests/test_organization.py
+++ b/server/app/tests/test_organization.py
@@ -326,3 +326,96 @@ class TestUpdateOrgDescByName:
         expected_calls = [call(org.name), call(org.name)]
         assert org_service.org_repo.find_by_name.call_args_list == expected_calls
 
+    @pytest.mark.parametrize("user_type", [("user"), ("admin")])
+    def integration_test(self, user_type):
+        with TestClient(app) as client:
+            def add_user(username):
+                data = {
+                    "username": username,
+                    "email": f"{username}@gmail.com",
+                    "password": "12345678"
+                }
+                response = client.post("/api/v1/users/", json=data)
+                return response.json()
+            
+            def log_in(username: str, password: str = "12345678"):
+                data = {
+                    "username": username,
+                    "password": password
+                }
+                response = client.post("/api/v1/users/login", json=data)
+                if response.status_code == 400:
+                    assert response.json() == False
+                jwt = response.json()["token"]
+                return jwt
+            
+            def change_superadmin_password():
+                # [1] Loading the super admin credentials
+                config_file = "./volume-server-cfg/superadmin_password.txt"
+
+                with open(config_file, "r") as f:
+                    old_password = f.readline()
+
+                jwt = log_in("admin", old_password)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+                # [2] Changing the super admin password
+                data = {
+                    "old_password": old_password,
+                    "new_password": "12345678"
+                }
+                response = client.post("/api/v1/users/password", json=data, headers=header)
+                assert response.is_success
+            
+            def add_admin(admin_username: str) -> dict:
+                jwt = log_in("admin", "12345678")
+                header = {"Authorization": f"Bearer {jwt}"}
+                data = {
+                    "username": admin_username,
+                    "email": f"{admin_username}@gmail.com",
+                    "password": "12345678"
+                }
+                response = client.post("/api/v1/users/register-admin", json=data, headers=header)
+                created_admin = response.json()
+
+                return created_admin
+
+            def add_org(username, name: str) -> dict:
+                jwt = log_in(username)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+                dto1 = {
+                    "name": name,
+                    "desc": "",
+                    "owner"
+                    "image": None
+                }
+                return client.post("/api/v1/organizations", json=dto1, headers=header).json()
+
+            def update_desc(username: str, org_name: str, desc: str):
+                jwt = log_in(username)
+                header = {"Authorization": f"Bearer {jwt}"}
+                
+                data = {
+                    "desc": desc
+                }
+
+                response = client.put(f"/api/v1/organizations/{org_name}/desc", json=data, headers=header)
+                return response
+
+            if (user_type == "user"):
+                add_user("u1")
+                add_user("u2")
+            else:
+                change_superadmin_password()
+                add_admin("u1")
+                add_admin("u2")
+
+            o1 = add_org("u1", "o1")
+           
+            # User who is the organization owner
+            assert update_desc("u1", o1["name"], "new desc").is_success
+            # User who is trying to update a non existing organization
+            assert update_desc("u1", "unknown org", "new desc").status_code == 400
+            # User who is not an organization owner
+            assert update_desc("u2", o1["id"], "new desc").status_code == 400

--- a/server/app/tests/test_organization.py
+++ b/server/app/tests/test_organization.py
@@ -2,12 +2,13 @@ from unittest.mock import MagicMock, call
 from fastapi.testclient import TestClient
 import pytest
 from app.api.org.org_service import OrganizationService
-from app.api.org.org_dto import OrganizationCreateDTO
-from app.api.config.exception_handler import FieldTakenException, NotFoundException
+from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDescUpdateDTO
+from app.api.config.exception_handler import AccessDeniedException, FieldTakenException, NotFoundException
 from app.api.config.exception_handler import FieldTakenException
 from app.api.main import app
 from app.api.repo.repo_model import Repository
 from app.api.org.org_model import Organization
+from app.api.user.user_model import User
 
 
 @pytest.fixture
@@ -267,3 +268,61 @@ class TestFindByName:
 
         org_service.org_repo.find_by_name.assert_called_once_with(org.name)
         assert result == org
+
+class TestUpdateOrgDescByName:
+
+    def test_org_not_exist(self, org_service):
+        """ Test case for when organization does not exist. """   
+        user_id = 1
+        dto = OrganizationDescUpdateDTO(desc="new desc")
+        org_name = "o1"
+        org_service.org_repo.find_by_name.return_value = None
+
+        with pytest.raises(NotFoundException):
+            org_service.update_desc_by_name(org_name, dto, user_id)
+
+        org_service.org_repo.set_attribute.assert_not_called()
+        org_service.org_repo.find_by_name.assert_called_once_with(org_name)
+
+    def test_non_eligible_user(self, org_service):
+        """ Test case for when the user is not eligible to make an update. """   
+        user_id = 1
+        dto = OrganizationDescUpdateDTO(desc="new desc")
+
+        owner = MagicMock(spec=User)
+        owner.id = 999999
+        org = MagicMock(spec=Organization)
+        org.name = "o1"
+        org.owner = owner        
+
+        org_service.org_repo.find_by_name.return_value = org
+
+        with pytest.raises(AccessDeniedException):
+            org_service.update_desc_by_name(org.name, dto, user_id)
+
+        org_service.org_repo.set_attribute.assert_not_called()
+        org_service.org_repo.find_by_name.assert_called_once_with(org.name)
+
+    def test_successful_update(self, org_service):
+        """ Test case for when the user is eligble and org does exist. """   
+        dto = OrganizationDescUpdateDTO(desc="new desc")
+        user = MagicMock(spec=User)
+        user.id = 1
+        org = MagicMock(spec=Organization)
+        org.name = "o1"
+        org.owner = user
+        org.desc = "old desc"
+
+        org_service.org_repo.find_by_name.return_value = org
+
+        org.desc = "new desc"
+        org_service.org_repo.set_attribute.return_value = org
+
+        result = org_service.update_desc_by_name(org.name, dto, user.id)
+
+        assert result.desc == "new desc"
+
+        org_service.org_repo.set_attribute.assert_called_once_with(org, "desc", "new desc")
+        expected_calls = [call(org.name), call(org.name)]
+        assert org_service.org_repo.find_by_name.call_args_list == expected_calls
+

--- a/server/app/tests/test_organization.py
+++ b/server/app/tests/test_organization.py
@@ -304,7 +304,7 @@ class TestUpdateOrgDescByName:
         org_service.org_repo.find_by_name.assert_called_once_with(org.name)
 
     def test_successful_update(self, org_service):
-        """ Test case for when the user is eligble and org does exist. """   
+        """ Test case for when the user is eligible and organization does exist. """   
         dto = OrganizationDescUpdateDTO(desc="new desc")
         user = MagicMock(spec=User)
         user.id = 1


### PR DESCRIPTION
Closes #48.

Introduced the `OrgOverview` component, as we previously had a draft version of the organization description under `OrgSettings`.  Perhaps we should replace the organization image next to the organization title, as that’s how DockerHub does it.