### PR TITLE
Bugfix, superadmin password change error message is ugly

### DIFF
--- a/client/src/pages/UserPasswordChangeRequired.tsx
+++ b/client/src/pages/UserPasswordChangeRequired.tsx
@@ -28,8 +28,19 @@ export const UserPasswordChangeRequired = () => {
             clearJWT();
             navigate("/login", { replace: true });
         }).catch((err: AxiosError) => {
-            console.error(err);
-            setError((err.response?.data as any)["detail"]["message"]);
+            let message = (err.response?.data as any)["detail"]["message"];
+            try {
+                if (typeof message == "string") {
+                    message = message.replace("'", "\"");
+                    const parsedMessage = JSON.parse(message);
+                    setError(parsedMessage[0]["msg"]);
+                } else {
+                    setError(message);
+                }
+            } catch (e) {
+                setError("Old password is incorrect or new password is invalid (must be at least 8 characters long and different from old password)");
+            }
+
         });
     };
 


### PR DESCRIPTION
Closes #6 

When changing the password, you would get an ugly JSON error message under certain errors. This is because the returned error JSON schema from the backend differs based on its origin (when we throw an exception, it would have one format which we can handle, but when Pydantic throws a validation error, it would return another one).

<img width="1027" height="575" alt="image" src="https://github.com/user-attachments/assets/5488365b-fb3c-4bc4-9550-c86db730a4ee" />

See the attached picture. Left is old, right is new.

I tried to join them by checking for the type of `["message"]` field. Unfortunately, Pydantic serialized JSON with single quotes (`'`) instead of double quotes (`"`), among other things which make the resulting JSON **invalid**... I couldn't parse it on the frontend. I tried messing with the exception-handler but it didn't help. That's why I added a fallback error message. It's an ugly hack, but seeing JSON on the web app is even uglier.