### PR TITLE
Fix ugly error message from Pydantic validation

### DIFF
--- a/client/src/pages/UserAdminRegistration.tsx
+++ b/client/src/pages/UserAdminRegistration.tsx
@@ -3,6 +3,7 @@ import { Form, Button, Container, Row, Col, Alert } from 'react-bootstrap';
 import './UserRegistration.css';
 import { UserRegisterDTO, UserService } from '../api/user.api';
 import { AxiosError } from 'axios';
+import { get_validation_error_readable } from '../util/http';
 
 const initialFormState = {
     username: '',
@@ -48,20 +49,7 @@ export const UserAdminRegistration = () => {
             setFormData(initialFormState);
             setSuccess("Admin " + dto.username + " is successfully registered!")
         }).catch((err: AxiosError) => {
-            try {
-                let err_msg = (err.response?.data as any)["detail"]["message"];
-                if (Array.isArray(err_msg)) {
-                    setError(err_msg[0]["msg"]);
-                } else if (typeof err_msg == "string") {
-                    setError(err_msg);
-                } else {
-                    setError((err.response?.data as any)["detail"]["message"]);
-                }
-            } catch (e) {
-                setError("Invalid user input");
-                console.error(e);
-                console.error(err.response?.data as any);
-            }
+            setError(get_validation_error_readable(err));
         });
     };
 

--- a/client/src/pages/UserAdminRegistration.tsx
+++ b/client/src/pages/UserAdminRegistration.tsx
@@ -48,7 +48,20 @@ export const UserAdminRegistration = () => {
             setFormData(initialFormState);
             setSuccess("Admin " + dto.username + " is successfully registered!")
         }).catch((err: AxiosError) => {
-            setError((err.response?.data as any)["detail"]["message"]);
+            try {
+                let err_msg = (err.response?.data as any)["detail"]["message"];
+                if (Array.isArray(err_msg)) {
+                    setError(err_msg[0]["msg"]);
+                } else if (typeof err_msg == "string") {
+                    setError(err_msg);
+                } else {
+                    setError((err.response?.data as any)["detail"]["message"]);
+                }
+            } catch (e) {
+                setError("Invalid user input");
+                console.error(e);
+                console.error(err.response?.data as any);
+            }
         });
     };
 

--- a/client/src/pages/UserPasswordChangeRequired.tsx
+++ b/client/src/pages/UserPasswordChangeRequired.tsx
@@ -4,6 +4,7 @@ import { UserPasswordChangeDTO, UserService } from '../api/user.api';
 import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { clearJWT } from '../util/localstorage';
+import { get_validation_error_readable } from '../util/http';
 
 export const UserPasswordChangeRequired = () => {
     let navigate = useNavigate();
@@ -28,19 +29,7 @@ export const UserPasswordChangeRequired = () => {
             clearJWT();
             navigate("/login", { replace: true });
         }).catch((err: AxiosError) => {
-            let message = (err.response?.data as any)["detail"]["message"];
-            try {
-                if (typeof message == "string") {
-                    message = message.replace("'", "\"");
-                    const parsedMessage = JSON.parse(message);
-                    setError(parsedMessage[0]["msg"]);
-                } else {
-                    setError(message);
-                }
-            } catch (e) {
-                setError("Old password is incorrect or new password is invalid (must be at least 8 characters long and different from old password)");
-            }
-
+            setError(get_validation_error_readable(err));
         });
     };
 

--- a/client/src/pages/UserRegistration.tsx
+++ b/client/src/pages/UserRegistration.tsx
@@ -43,7 +43,20 @@ export const UserRegistration = () => {
         UserService.RegisterRegularUser(dto).then(() => {
             navigate("/login");
         }).catch((err: AxiosError) => {
-            setError((err.response?.data as any)["detail"]["message"]);
+            try {
+                let err_msg = (err.response?.data as any)["detail"]["message"];
+                if (Array.isArray(err_msg)) {
+                    setError(err_msg[0]["msg"]);
+                } else if (typeof err_msg == "string") {
+                    setError(err_msg);
+                } else {
+                    setError((err.response?.data as any)["detail"]["message"]);
+                }
+            } catch (e) {
+                setError("Invalid user input");
+                console.error(e);
+                console.error(err.response?.data as any);
+            }
         });
     };
 

--- a/client/src/pages/UserRegistration.tsx
+++ b/client/src/pages/UserRegistration.tsx
@@ -4,6 +4,7 @@ import './UserRegistration.css';
 import { UserRegisterDTO, UserService } from '../api/user.api';
 import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { get_validation_error_readable } from '../util/http';
 
 export const UserRegistration = () => {
     let navigate = useNavigate();
@@ -43,20 +44,7 @@ export const UserRegistration = () => {
         UserService.RegisterRegularUser(dto).then(() => {
             navigate("/login");
         }).catch((err: AxiosError) => {
-            try {
-                let err_msg = (err.response?.data as any)["detail"]["message"];
-                if (Array.isArray(err_msg)) {
-                    setError(err_msg[0]["msg"]);
-                } else if (typeof err_msg == "string") {
-                    setError(err_msg);
-                } else {
-                    setError((err.response?.data as any)["detail"]["message"]);
-                }
-            } catch (e) {
-                setError("Invalid user input");
-                console.error(e);
-                console.error(err.response?.data as any);
-            }
+            setError(get_validation_error_readable(err));
         });
     };
 

--- a/client/src/util/http.ts
+++ b/client/src/util/http.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { AxiosError } from 'axios';
 import { getJWTStringOrNull } from "./localstorage";
 
 export const ENV = {
@@ -22,3 +23,27 @@ axiosInstance.interceptors.request.use(
         console.error(error);
     }
 );
+
+/**
+ * Given an error received from the API (notably, the server), create a
+ * human-readable string that can be shown on the web app. 
+ * @throws Never
+ * @param err Axios error
+ * @returns A human-readable string that can be shown on the web app
+ */
+export const get_validation_error_readable = (err: AxiosError): string => {
+    try {
+        let err_msg = (err.response?.data as any)["detail"]["message"];
+        if (Array.isArray(err_msg)) {
+            return err_msg[0]["msg"];
+        } else if (typeof err_msg == "string") {
+            return err_msg;
+        } else {
+            return (err.response?.data as any)["detail"]["message"];
+        }
+    } catch (e) {
+        console.error(e);
+        console.error(err.response?.data as any);
+        return "Invalid user input";
+    }
+}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,21 +1,23 @@
+# syntax=docker/dockerfile:1.4
 FROM python:3.10.15-alpine3.20
-
 WORKDIR /code
+
+# --no-cache removed
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add 7zip
 
 COPY ./requirements.txt /code/requirements.txt
 
-RUN apk add 7zip --no-cache
-
-RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+#  --no-cache-dir removed
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade -r /code/requirements.txt
 
 COPY ./app /code/app
 
 RUN mkdir -p /code/logs
-
 RUN mkdir -p /code/certs
 
 COPY ./entrypoint.sh /code/entrypoint.sh
-RUN ls -l /code
 RUN chmod +x /code/entrypoint.sh
 
 ENTRYPOINT ["/code/entrypoint.sh"]

--- a/server/app/api/config/exception_handler.py
+++ b/server/app/api/config/exception_handler.py
@@ -73,7 +73,7 @@ def register_exception_handler(app: FastAPI):
     
     @app.exception_handler(RequestValidationError)
     def _ValidationError(r: Request, e: RequestValidationError):
-        raise HTTPException(400, detail={"message": str(e.errors())})
+        raise HTTPException(400, detail={"message": e.errors()})
     
     @app.exception_handler(sqlalchemy.exc.IntegrityError)
     def _IntegrityError(r: Request, e: sqlalchemy.exc.IntegrityError):


### PR DESCRIPTION
Closes #53, #2 (and also #3, because there weren't any fixes I could do specifically for the `admin-register` feature).

See the attached image for the before and after:

<img width="717" height="287" alt="image" src="https://github.com/user-attachments/assets/f8fa067a-1c4a-4b64-be27-506d30a89705" />
 
Commit rundown:

- 3ac70da I added _cache mounts_ to the server's Dockerfile. I got this idea from our DevOps course, as this can vastly improve build times. The first time you run `docker compose build`, it'll take some time because layer cache is invalidated, but subsequent builds should take less and less time. I also changed the order of `RUN apk add 7zip` and `COPY requirements.txt` (we should add 7zip _before_ copying requirements, because otherwise docker will invalidate the 7zip layer cache every time we change requirements.txt).
- 6a7317c This was the core of the error (as well as yesterday's #51 PR). For some reason, the server was explicitly converting Pydantic errors to a string before sending them as a response. Removing `str()` fixed it (now FastAPI deals with serialization, and it does the job correctly).
- 40fe289 In the user registration page, I added better validation (Pydantic errors are an array of JSON objects, so the frontend app checks if the error message is an array first; and also, there is a fallback error message just in case).
- f63e3c2 Ditto for admin registration page
- d742e6b The same code is run in two different components. I extracted the code into its own function in `util/http.ts`. I also decided to use the function for the password reset page.