### PR TITLE
Analytics section

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,8 +17,10 @@
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.5",
         "react-dom": "^18.3.1",
+        "react-markdown": "^10.1.0",
         "react-responsive-pagination": "^2.10.0",
         "react-router-dom": "^7.0.1",
+        "react-use": "^17.6.0",
         "sass": "1.77.6",
         "zustand": "^5.0.1"
       },
@@ -916,8 +918,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1323,17 +1324,58 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
       "version": "22.9.0",
@@ -1374,6 +1416,11 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.3",
@@ -1610,6 +1657,11 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.3.tgz",
@@ -1628,6 +1680,11 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0"
       }
+    },
+    "node_modules/@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -1712,6 +1769,15 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -1873,6 +1939,15 @@
         }
       ]
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1887,6 +1962,42 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -1957,6 +2068,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1977,6 +2097,14 @@
         "node": ">=18"
       }
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
@@ -1989,6 +2117,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/csstype": {
@@ -2009,7 +2157,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2020,6 +2167,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -2044,6 +2203,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -2058,6 +2229,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.62.tgz",
       "integrity": "sha512-t8c+zLmJHa9dJy96yBZRXGQYoiCEnHYgFwn1asvSPZSUdVxnB62A4RASd7k41ytG3ErFBA0TpHlKg9D9SQBmLg==",
       "dev": true
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2276,6 +2455,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2285,11 +2473,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -2330,6 +2522,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "node_modules/fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -2491,6 +2693,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2549,12 +2803,47 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-binary-path": {
@@ -2566,6 +2855,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -2587,6 +2885,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2595,11 +2902,27 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2711,6 +3034,15 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2731,6 +3063,156 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2739,6 +3221,427 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -2787,8 +3690,26 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nano-css": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
+      "integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "css-tree": "^1.1.2",
+        "csstype": "^3.1.2",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^7.0.1",
+        "rtl-css-js": "^1.16.1",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -2895,6 +3816,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2987,6 +3931,15 @@
       },
       "peerDependencies": {
         "react": ">=0.14.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/proxy-from-env": {
@@ -3085,6 +4038,32 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -3159,6 +4138,40 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "peerDependencies": {
+        "react": "*",
+        "tslib": "*"
+      }
+    },
+    "node_modules/react-use": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.0.tgz",
+      "integrity": "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==",
+      "dependencies": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.6.2",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3174,6 +4187,42 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3231,6 +4280,14 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3278,6 +4335,17 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -3291,6 +4359,14 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+    },
+    "node_modules/set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
+      "engines": {
+        "node": ">=6.9"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3313,12 +4389,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3333,6 +4479,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-to-js": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
+      "dependencies": {
+        "style-to-object": "1.0.9"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3343,6 +4510,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/to-regex-range": {
@@ -3356,6 +4531,29 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.0.tgz",
@@ -3367,6 +4565,11 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -3446,6 +4649,87 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -3483,6 +4767,32 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -3620,6 +4930,15 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   },
@@ -4143,8 +5462,7 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -4416,17 +5734,58 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
+    "@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+    },
+    "@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
+    "@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
+    "@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
     },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
+    "@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "@types/node": {
       "version": "22.9.0",
@@ -4467,6 +5826,11 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "@types/warning": {
       "version": "3.0.3",
@@ -4603,6 +5967,11 @@
         }
       }
     },
+    "@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
+    },
     "@vitejs/plugin-react": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.3.tgz",
@@ -4615,6 +5984,11 @@
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.14.2"
       }
+    },
+    "@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "acorn": {
       "version": "8.14.0",
@@ -4679,6 +6053,11 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -4753,6 +6132,11 @@
       "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
       "dev": true
     },
+    "ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4762,6 +6146,26 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+    },
+    "character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
+    },
+    "character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+    },
+    "character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
     },
     "chokidar": {
       "version": "3.6.0",
@@ -4816,6 +6220,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4833,6 +6242,14 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
       "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
     },
+    "copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
@@ -4842,6 +6259,23 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "requires": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
       }
     },
     "csstype": {
@@ -4858,9 +6292,16 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.3"
+      }
+    },
+    "decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "requires": {
+        "character-entities": "^2.0.0"
       }
     },
     "deep-is": {
@@ -4879,6 +6320,14 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
+    "devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "requires": {
+        "dequal": "^2.0.0"
+      }
+    },
     "dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -4893,6 +6342,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.62.tgz",
       "integrity": "sha512-t8c+zLmJHa9dJy96yBZRXGQYoiCEnHYgFwn1asvSPZSUdVxnB62A4RASd7k41ytG3ErFBA0TpHlKg9D9SQBmLg==",
       "dev": true
+    },
+    "error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "requires": {
+        "stackframe": "^1.3.4"
+      }
     },
     "esbuild": {
       "version": "0.21.5",
@@ -5044,17 +6501,26 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
+    "estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.3.2",
@@ -5091,6 +6557,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "fastq": {
       "version": "1.17.1",
@@ -5198,6 +6674,46 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "requires": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "requires": {
+        "@types/hast": "^3.0.0"
+      }
+    },
+    "html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="
+    },
+    "hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5230,12 +6746,39 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
+    "inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="
+    },
+    "inline-style-prefixer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+      "requires": {
+        "css-in-js-utils": "^3.1.0"
+      }
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
+    },
+    "is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "requires": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
       }
     },
     "is-binary-path": {
@@ -5245,6 +6788,11 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -5259,16 +6807,31 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -5353,6 +6916,11 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5370,11 +6938,340 @@
         "yallist": "^3.0.2"
       }
     },
+    "mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      }
+    },
+    "mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "requires": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      }
+    },
+    "mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "requires": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "requires": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      }
+    },
+    "mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      }
+    },
+    "mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      }
+    },
+    "mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "requires": {
+        "@types/mdast": "^4.0.0"
+      }
+    },
+    "mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
+    },
+    "micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "requires": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "requires": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "requires": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "requires": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="
+    },
+    "micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="
+    },
+    "micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "requires": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="
+    },
+    "micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="
     },
     "micromatch": {
       "version": "4.0.8",
@@ -5411,8 +7308,22 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "nano-css": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
+      "integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "css-tree": "^1.1.2",
+        "csstype": "^3.1.2",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^7.0.1",
+        "rtl-css-js": "^1.16.1",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.3.0"
+      }
     },
     "nanoid": {
       "version": "3.3.7",
@@ -5483,6 +7394,27 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "2.0.11",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+          "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+        }
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5541,6 +7473,11 @@
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
       }
+    },
+    "property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -5605,6 +7542,24 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      }
+    },
     "react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -5649,6 +7604,33 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "requires": {}
+    },
+    "react-use": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.0.tgz",
+      "integrity": "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==",
+      "requires": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.6.2",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5661,6 +7643,34 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
+    "remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      }
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -5702,6 +7712,14 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5729,6 +7747,11 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
+    },
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5739,6 +7762,11 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+    },
+    "set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -5755,16 +7783,95 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
     "source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
+    },
+    "space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+    },
+    "stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "requires": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA=="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
+    },
+    "stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "requires": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "style-to-js": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
+      "requires": {
+        "style-to-object": "1.0.9"
+      }
+    },
+    "style-to-object": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "requires": {
+        "inline-style-parser": "0.2.4"
+      }
+    },
+    "stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="
     },
     "supports-color": {
       "version": "7.2.0",
@@ -5775,6 +7882,11 @@
         "has-flag": "^4.0.0"
       }
     },
+    "throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5783,12 +7895,32 @@
         "is-number": "^7.0.0"
       }
     },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
+    "trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
+    },
+    "trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+    },
     "ts-api-utils": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.0.tgz",
       "integrity": "sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==",
       "dev": true,
       "requires": {}
+    },
+    "ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "tslib": {
       "version": "2.8.1",
@@ -5843,6 +7975,63 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
+    "unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      }
+    },
     "update-browserslist-db": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -5860,6 +8049,24 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
       }
     },
     "vite": {
@@ -5914,6 +8121,11 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
       "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
       "requires": {}
+    },
+    "zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.5",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
     "react-responsive-pagination": "^2.10.0",
     "react-router-dom": "^7.0.1",
     "react-use": "^17.6.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ import { OrganizationPage } from './pages/OrgPage';
 import { RepoStarred } from './pages/RepoStarred';
 import { OrganisationsOfUser } from './pages/OrgOfUser';
 import { ProfilePage } from './pages/ProfilePage';
+import { Analytics } from './pages/Analytics';
 
 // This function converts:
 //
@@ -69,6 +70,7 @@ function App() {
                     {/* Protected routes. */}
                     {authRoute("/new", ['user', 'admin'], RepoCreate)}
                     {authRoute("/org", ['user', 'admin'], OrganizationCreate)}
+                    {authRoute("/analytics", ['admin', 'superadmin'], Analytics)}
 
                     {/* "Not found", must be at the end. */}
                     {authRoute("*", [], NotFound)}

--- a/client/src/api/logs.api.ts
+++ b/client/src/api/logs.api.ts
@@ -2,11 +2,11 @@ import axios, { AxiosResponse } from "axios";
 import { axiosInstance, ENV } from "../util/http";
 
 export enum LogLevel {
-    info,
-    warning,
-    error,
-    trace,
-    debug,
+    info = 'info',
+    warning = 'warning',
+    error = 'error',
+    trace = 'trace',
+    debug = 'debug',
 }
 
 export interface LogDTO {

--- a/client/src/api/logs.api.ts
+++ b/client/src/api/logs.api.ts
@@ -1,0 +1,43 @@
+import axios, { AxiosResponse } from "axios";
+import { axiosInstance, ENV } from "../util/http";
+
+export enum LogLevel {
+    info,
+    warning,
+    error,
+    trace,
+    debug,
+}
+
+export interface LogDTO {
+    date_time: string,
+    level: LogLevel,
+    text: string,
+}
+
+export interface LogQueryInfoDTO {
+    page: number,
+    page_size: number,
+    total_pages: number,
+    total_hits: number,
+}
+
+export interface LogQueryDTO {
+    hits: LogDTO[],
+    info: LogQueryInfoDTO
+}
+
+export class LogsService {
+    static async Search(query: string, page: number, page_size: number, sort_by: string, sort_ascending: boolean): Promise<AxiosResponse<LogQueryDTO>> {
+        // TODO: Once we put the searching inside the main server, use axiosInstance and the proper endpoint.
+        return await axios.get('http://127.0.0.1:8068/search_logs', {
+            params: {
+                query,
+                page_number: page,
+                page_size,
+                sort_by,
+                sort_ascending,
+            },
+        });
+    }
+}

--- a/client/src/api/logs.api.ts
+++ b/client/src/api/logs.api.ts
@@ -29,8 +29,7 @@ export interface LogQueryDTO {
 
 export class LogsService {
     static async Search(query: string, page: number, page_size: number, sort_by: string, sort_ascending: boolean): Promise<AxiosResponse<LogQueryDTO>> {
-        // TODO: Once we put the searching inside the main server, use axiosInstance and the proper endpoint.
-        return await axios.get('http://127.0.0.1:8068/search_logs', {
+        return await axiosInstance.get("/events/", {
             params: {
                 query,
                 page_number: page,

--- a/client/src/components/AnalyticsSidebar.css
+++ b/client/src/components/AnalyticsSidebar.css
@@ -1,0 +1,53 @@
+.sidebar {
+    width: 35%;
+    background-color: #f8f9fa;
+    border-right: 1px solid #dee2e6;
+    padding: 1rem;
+}
+
+.sidebar-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.query-list {
+    margin-top: 1rem;
+    padding-left: 1rem;
+}
+
+.query-list li {
+    margin-bottom: 0.5rem;
+}
+
+.query-description {
+    font-size: 0.9rem;
+    color: #555;
+    margin-top: 0.25rem;
+}
+
+.sidebar h1 {
+    font-size: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.sidebar h2 {
+    font-size: 1rem;
+    margin-bottom: 0.25rem;
+
+}
+
+.sidebar code {
+    background-color: #f1f1f1;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-family: monospace;
+}

--- a/client/src/components/AnalyticsSidebar.tsx
+++ b/client/src/components/AnalyticsSidebar.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { AxiosError, AxiosResponse } from 'axios';
+import { LogLevel, LogQueryDTO, LogsService } from '../api/logs.api';
+import Spinner from 'react-bootstrap/Spinner';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import { Row, Col, Table } from 'react-bootstrap';
+import { Pagination } from 'react-bootstrap';
+import "./AnalyticsSidebar.css";
+import ReactMarkdown from 'react-markdown';
+
+interface SidebarProps {
+    onClose: () => void;
+}
+
+const markdownContent = `
+# **Help**
+
+# Keywords
+
+## (1) \`text_content\`
+The text of the log.
+
+- \`text_content ~= "error issue couldn't not"\`
+\\
+Search by keywords (any match)
+
+- \`text_content ~= "tried to get"\`
+\\
+Search by term (whole term must match)
+
+## (2) \`log_level\`
+
+Supports: \`info\`, \`warning\`, \`error\`, \`trace\` and \`debug\`.
+
+- \`log_level == "info"\`
+\\
+Search all logs with the \`info\` badge.
+
+- \`log_level == "info" or log_level == "error"\`
+\\
+Search all logs with the \`info\` _or_ \`error\` badge.
+
+## (3) \`date_time\`
+
+Dates can be compared using \`>\`, \`>=\`, \`<\`, \`<=\` and \`==\`.
+
+- \`date_time <= "2025-07-27T08:06:10"\`
+\\
+Get logs submitted before the 27th of July 2025 at 08:06:10.
+
+- \`date_time >= "2025-07-01" and date_time < "2025-07-27"\`
+\\
+Get logs submitted before 1st of July 2025 and 27th of July 2025.
+
+# Complex queries
+
+- \`(log_level == "warning" or log_level == "debug") and text_content ~= "http failure"\`
+- \`(log_level == "info" or log_level == "debug") and (text_content ~~= "HTTP connection" or date_time >= "2025-07-25")\`
+`;
+
+export const AnalyticsSidebar: React.FC<SidebarProps> = ({ onClose }) => {
+    return (
+        <div className="sidebar">
+            <button className="close-btn" onClick={onClose}>×</button>
+            <ReactMarkdown>{markdownContent}</ReactMarkdown>
+        </div>
+    );
+};
+

--- a/client/src/components/AnalyticsSidebar.tsx
+++ b/client/src/components/AnalyticsSidebar.tsx
@@ -51,7 +51,7 @@ Get logs submitted before the 27th of July 2025 at 08:06:10.
 
 - \`date_time >= "2025-07-01" and date_time < "2025-07-27"\`
 \\
-Get logs submitted before 1st of July 2025 and 27th of July 2025.
+Get logs submitted between 1st of July 2025 and 27th of July 2025.
 
 # Complex queries
 

--- a/client/src/components/AnalyticsSidebar.tsx
+++ b/client/src/components/AnalyticsSidebar.tsx
@@ -21,13 +21,13 @@ const markdownContent = `
 ## (1) \`text_content\`
 The text of the log.
 
-- \`text_content ~= "error issue couldn't not"\`
+- \`text_content ~= "not don't couldn't no"\`
 \\
-Search by keywords (any match)
+Search by keywords (if any word is found, it's a match)
 
-- \`text_content ~= "tried to get"\`
+- \`text_content ~~= "tried to get"\`
 \\
-Search by term (whole term must match)
+Search by term (the whole term must match)
 
 ## (2) \`log_level\`
 
@@ -57,6 +57,7 @@ Get logs submitted before 1st of July 2025 and 27th of July 2025.
 
 - \`(log_level == "warning" or log_level == "debug") and text_content ~= "http failure"\`
 - \`(log_level == "info" or log_level == "debug") and (text_content ~~= "HTTP connection" or date_time >= "2025-07-25")\`
+- \`log_level == "error" and not text_content ~= "HTTP"\`
 `;
 
 export const AnalyticsSidebar: React.FC<SidebarProps> = ({ onClose }) => {

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ import { useClickAway } from "react-use";
 
 export function Navbar() {
     const role = useAuthStore((state) => state.role); // "" if no JWT.
-    const username = getJwtUsername(); 
+    const username = getJwtUsername();
     const [showDropdown, setShowDropdown] = useState(false);
     const dropdownRef = useRef(null);
     const handleDropdownClick = () => setShowDropdown(false);
@@ -20,57 +20,57 @@ export function Navbar() {
         <nav className="navbar-container">
             {/* Left */}
             <NavLink className={"navlink bold"} to="/" end><span className="white">Mocker</span><span className="blue">Hub</span></NavLink>
-            
+
             {/* Center*/}
             <div className="navbar-center">
-            {
-                role === 'superadmin' &&
-                <>
-                    <NavLink className={"navlink"} to="/register-admin" end><i className="bi bi-person-plus"></i>New admin</NavLink>
+                {
+                    role === 'superadmin' &&
+                    <>
+                        <NavLink className={"navlink"} to="/register-admin" end><i className="bi bi-person-plus"></i>New admin</NavLink>
 
-                </>
-            }
-            {
-                role !== '' &&
-                <>
-                    <NavLink className={"navlink"} to="/." end><i className="bi bi-search"></i>Explore</NavLink>
-                    <NavLink className={"navlink"} to={`/u/${username}/repos`} end><i className="bi bi-collection"></i>Repositories</NavLink>
-                    <NavLink className={"navlink"} to={`/u/${username}/orgs`} end><i className="bi bi-building"></i>Organizations</NavLink>
-                </>
-            }
-                        {
-                (role === 'admin' || role === 'superadmin') &&
-                <>
-                    <NavLink className={"navlink"} to="" end><i className="bi bi-people"></i>Users</NavLink>
-                    <NavLink className={"navlink"} to="" end><i className="bi bi-graph-up"></i>Analytics</NavLink>
-                </>
-            }
+                    </>
+                }
+                {
+                    role !== '' &&
+                    <>
+                        <NavLink className={"navlink"} to="/." end><i className="bi bi-search"></i>Explore</NavLink>
+                        <NavLink className={"navlink"} to={`/u/${username}/repos`} end><i className="bi bi-collection"></i>Repositories</NavLink>
+                        <NavLink className={"navlink"} to={`/u/${username}/orgs`} end><i className="bi bi-building"></i>Organizations</NavLink>
+                    </>
+                }
+                {
+                    (role === 'admin' || role === 'superadmin') &&
+                    <>
+                        <NavLink className={"navlink"} to="" end><i className="bi bi-people"></i>Users</NavLink>
+                        <NavLink className={"navlink"} to="/analytics" end><i className="bi bi-graph-up"></i>Analytics</NavLink>
+                    </>
+                }
             </div>
 
             {/* Right */}
             <div className="navbar-right" ref={dropdownRef}>
-            {
-                role === '' &&
-                <>
-                    <NavLink className={"navlink"} to="/login" end>Log in</NavLink>
-                    <NavLink className={"navlink bordered"} to="/register" end>Sign Up</NavLink>
-                </>
-            }
-            {
-                role !== '' &&
-                <>
-                    <span className="username"  onClick={() => setShowDropdown(!showDropdown)}>{username} <i className="bi-caret-down-fill"></i> </span>
-                    {showDropdown && (
-                        <div className="dropdown-menu">
-                            <NavLink to={`/u/${username}`} onClick={handleDropdownClick}><i className="bi bi-person"></i>Profile</NavLink>
-                            {role === "user" && (
-                            <NavLink to={`/u/${username}/starred`} onClick={handleDropdownClick}><i className="bi bi-star"></i>Starred Repositories</NavLink>
-                            )}
-                            <NavLink to="/logout" onClick={handleDropdownClick}><i className="bi bi-box-arrow-right"></i>Log out</NavLink>
-                        </div>
-                    )}
-                </>
-            }
+                {
+                    role === '' &&
+                    <>
+                        <NavLink className={"navlink"} to="/login" end>Log in</NavLink>
+                        <NavLink className={"navlink bordered"} to="/register" end>Sign Up</NavLink>
+                    </>
+                }
+                {
+                    role !== '' &&
+                    <>
+                        <span className="username" onClick={() => setShowDropdown(!showDropdown)}>{username} <i className="bi-caret-down-fill"></i> </span>
+                        {showDropdown && (
+                            <div className="dropdown-menu">
+                                <NavLink to={`/u/${username}`} onClick={handleDropdownClick}><i className="bi bi-person"></i>Profile</NavLink>
+                                {role === "user" && (
+                                    <NavLink to={`/u/${username}/starred`} onClick={handleDropdownClick}><i className="bi bi-star"></i>Starred Repositories</NavLink>
+                                )}
+                                <NavLink to="/logout" onClick={handleDropdownClick}><i className="bi bi-box-arrow-right"></i>Log out</NavLink>
+                            </div>
+                        )}
+                    </>
+                }
             </div>
         </nav>
     );

--- a/client/src/pages/Analytics.css
+++ b/client/src/pages/Analytics.css
@@ -1,0 +1,10 @@
+.page-container {
+    display: flex;
+    width: 100%;
+    min-height: 100vh;
+}
+
+.main-content {
+    flex: 1;
+    padding: 2rem;
+}

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -1,24 +1,50 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AxiosError, AxiosResponse } from 'axios';
-import { LogQueryDTO, LogsService } from '../api/logs.api';
+import { LogLevel, LogQueryDTO, LogsService } from '../api/logs.api';
+import Spinner from 'react-bootstrap/Spinner';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import { Row, Col, Table } from 'react-bootstrap';
+import { Pagination } from 'react-bootstrap';
 
 export const Analytics = () => {
     const [query, setQuery] = useState('log_level == "info"');
     const [pageNumber, setPageNumber] = useState(1);
     const [pageSize, setPageSize] = useState(10);
-    const [sortBy, setSortBy] = useState('timestamp');
+    const [sortBy, setSortBy] = useState('date_time');
     const [sortAscending, setSortAscending] = useState(true);
     const [logs, setLogs] = useState<LogQueryDTO | null>(null);
-    // const [totalResults, setTotalResults] = useState(0);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');
 
+    const getSortIcon = (column: string) => {
+        if (sortBy !== column) return null;
+        return sortAscending ? '▲' : '▼';
+    };
+
+    const getLevelVariant = (level: string) => {
+        switch (level.toLowerCase()) {
+            case 'error':
+                return 'danger';
+            case 'warning':
+                return 'warning';
+            case 'info':
+                return 'info';
+            case 'debug':
+                return 'primary';
+            default:
+                return 'secondary';
+        }
+    };
+
     const handleSearch = async () => {
-        setLoading(true);
+        if (logs === null) {
+            setLoading(true);
+        }
+
         setError('');
 
         LogsService.Search(query, pageNumber, pageSize, sortBy, sortAscending).then((res: AxiosResponse<LogQueryDTO>) => {
-            console.log(res.data);
             setLogs(res.data);
         }).catch((err: AxiosError) => {
             setError(err.message || 'Failed to fetch logs');
@@ -26,67 +52,183 @@ export const Analytics = () => {
         }).finally(() => {
             setLoading(false);
         });
+    };
 
+    const handleSort = (column: string) => {
+        if (sortBy === column) {
+            setSortAscending(!sortAscending);
+        } else {
+            setSortBy(column);
+            setSortAscending(true);
+        }
+        handleSearch();
+    };
+
+    const handlePageChange = (page: number) => {
+        setPageNumber(page);
+    };
+
+    useEffect(() => {
+        handleSearch();
+    }, [pageNumber]);
+    useEffect(() => {
+        handleSearch();
+    }, [pageSize]);
+
+    const renderPagination = () => {
+        if (!logs || logs.info.total_pages <= 1) return null;
+
+        const items = [];
+        const maxPagesToShow = 10;
+        const startPage = Math.max(1, logs.info.page - Math.floor(maxPagesToShow / 2));
+        const endPage = Math.min(logs.info.total_pages, startPage + maxPagesToShow - 1);
+
+        items.push(
+            <Pagination.First
+                key="prev"
+                onClick={() => handlePageChange(1)}
+                style={{ width: '48px', textAlign: 'center' }}
+            />
+        );
+
+        items.push(
+            <Pagination.Prev
+                key="prev"
+                disabled={logs.info.page <= 1}
+                onClick={() => handlePageChange(logs.info.page - 1)}
+                style={{ width: '48px', textAlign: 'center' }}
+            />
+        );
+
+
+        for (let page = startPage; page <= endPage; page++) {
+            items.push(
+                <Pagination.Item
+                    key={page}
+                    active={page === logs.info.page}
+                    onClick={() => handlePageChange(page)}
+                    style={{ width: '48px', textAlign: 'center' }}
+                >
+                    {page}
+                </Pagination.Item>
+            );
+        }
+
+        items.push(
+            <Pagination.Next
+                key="next"
+                disabled={logs.info.page >= logs.info.total_pages}
+                onClick={() => handlePageChange(logs.info.page + 1)}
+                style={{ width: '48px', textAlign: 'center' }}
+            />
+        );
+
+        items.push(
+            <Pagination.Last
+                key="prev"
+                onClick={() => handlePageChange(logs.info.total_pages)}
+                style={{ width: '48px', textAlign: 'center' }}
+            />
+        );
+
+        return <Pagination>{items}</Pagination>;
     };
 
     return (
         <div style={{ padding: '2rem' }}>
-            <h2>Log Search</h2>
-            <div style={{ marginBottom: '1rem' }}>
-                <input
-                    type="text"
-                    placeholder="Search query"
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                />
-                <input
-                    type="number"
-                    placeholder="Page number"
-                    value={pageNumber}
-                    onChange={(e) => setPageNumber(Number(e.target.value))}
-                />
-                <input
-                    type="number"
-                    placeholder="Page size"
-                    value={pageSize}
-                    onChange={(e) => setPageSize(Number(e.target.value))}
-                />
-                <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
-                    <option value="date_time">Timestamp</option>
-                    <option value="log_level">Level</option>
-                </select>
-                <label>
-                    <input
-                        type="checkbox"
-                        checked={sortAscending}
-                        onChange={(e) => setSortAscending(e.target.checked)}
-                    />
-                    Sort Ascending
-                </label>
-                <button onClick={handleSearch}>Search</button>
-            </div>
+            <h2 className="text-center">
+                <i className="bi-graph-up"></i> Log Search
+            </h2>
 
-            {loading && <p>Loading...</p>}
+            <Form className="mb-3">
+                <Row className="g-3 align-items-end">
+                    <Col xs={9} md={11}>
+                        <Form.Group controlId="searchQuery">
+                            <Form.Label>Search Query</Form.Label>
+                            <Form.Control
+                                type="text"
+                                placeholder="Enter search query"
+                                value={query}
+                                onChange={(e) => setQuery(e.target.value)}
+                            />
+                        </Form.Group>
+                    </Col>
+
+                    <Col xs={3} md={1}>
+                        <Button variant="primary" onClick={handleSearch} className="w-100">
+                            Search
+                        </Button>
+                    </Col>
+                </Row>
+            </Form>
+
+            {loading && <Spinner animation="border" variant="primary" role="status"></Spinner>}
             {error && <p style={{ color: 'red' }}>{error}</p>}
 
-            {logs !== null &&
-                <span>
+            {logs !== null && (
+                <>
+                    <div className="d-flex flex-wrap gap-3 mt-3 align-items-start">
+                        {/* Pagination */}
+                        <div>
+                            {renderPagination()}
+                        </div>
 
-                    <ul>
-                        {logs.hits.map((log, index) => (
-                            <li key={index}>
-                                <strong>{log.date_time}</strong> [{log.level}] - {log.text}
-                            </li>
-                        ))}
-                    </ul>
-
-                    <div>
-                        Page {logs.info.page} of {logs.info.total_pages} <br />
-                        Showing {logs.info.page_size} of {logs.info.total_hits} logs <br />
+                        {/* Page size dropdown with inline label */}
+                        <div className="d-flex align-items-center gap-2">
+                            <label htmlFor="pageSizeSelect" className="mb-0">Rows per page:</label>
+                            <Form.Select
+                                id="pageSizeSelect"
+                                value={pageSize}
+                                onChange={(e) => {
+                                    setPageSize(Number(e.target.value));
+                                    setPageNumber(1);
+                                }}
+                                style={{ width: '100px' }}
+                            >
+                                {[5, 10, 25, 50, 100].map((size) => (
+                                    <option key={size} value={size}>
+                                        {size}
+                                    </option>
+                                ))}
+                            </Form.Select>
+                        </div>
                     </div>
 
-                </span>
-            }
-        </div >
+                    {/* Log count */}
+                    <div>
+                        Showing <strong>{logs.hits.length}</strong> of <strong>{logs.info.total_hits}</strong> logs
+                    </div>
+
+                    <div style={{ maxHeight: '600px', overflowY: 'auto', overflowX: 'auto' }}>
+                        <Table striped bordered hover responsive style={{ tableLayout: 'fixed', width: '100%' }}>
+                            <thead>
+                                <tr>
+                                    <th style={{ width: '200px', cursor: 'pointer' }} onClick={() => handleSort('date_time')}>
+                                        Timestamp {getSortIcon('date_time')}
+                                    </th>
+                                    <th style={{ width: '120px', cursor: 'pointer' }} onClick={() => handleSort('log_level')}>
+                                        Level {getSortIcon('log_level')}
+                                    </th>
+                                    <th style={{ width: '600px' }}>Message</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {logs.hits.map((log, index) => (
+                                    <tr key={index}>
+                                        <td>{new Date(log.date_time).toLocaleString()}</td>
+                                        <td>
+                                            <span className={`badge bg-${getLevelVariant(log.level.toString())}`}>
+                                                {log.level}
+                                            </span>
+                                        </td>
+                                        <td>{log.text}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </Table>
+                    </div>
+                </>
+            )}
+        </div>
     );
 };

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -9,6 +9,7 @@ import { Pagination } from 'react-bootstrap';
 import "./Analytics.css";
 import ReactMarkdown from 'react-markdown';
 import { AnalyticsSidebar } from '../components/AnalyticsSidebar';
+import { log } from 'console';
 
 export const Analytics = () => {
     const [query, setQuery] = useState("");
@@ -47,7 +48,7 @@ export const Analytics = () => {
             setError('');
             return;
         }
-        if (logs === null) {
+        if (logs === null || logs.hits.length == 0) {
             setLoading(true);
         }
 
@@ -55,6 +56,9 @@ export const Analytics = () => {
 
         LogsService.Search(query, pageNumber, pageSize, sortBy, sortAscending).then((res: AxiosResponse<LogQueryDTO>) => {
             setLogs(res.data);
+            if (res.data.info.page > res.data.info.total_pages) {
+                handlePageChange(res.data.info.total_pages);
+            }
         }).catch((err: AxiosError) => {
             setError(err.message || 'Failed to fetch logs');
             setLogs(null);
@@ -150,7 +154,10 @@ export const Analytics = () => {
                     <i className="bi-graph-up"></i> Log Search
                 </h2>
 
-                <Form className="mb-3">
+                <Form className="mb-3" onSubmit={(e) => {
+                    e.preventDefault(); // Prevent page reload
+                    handleSearch();     // Trigger search logic
+                }}>
                     <Row className="g-3 align-items-end">
                         <Col xs={0}>
                             <Form.Group controlId="searchQuery">
@@ -164,13 +171,13 @@ export const Analytics = () => {
                             </Form.Group>
                         </Col>
 
-                        <Col xs='auto'>
-                            <Button variant="primary" onClick={handleSearch}>
+                        <Col xs="auto">
+                            <Button variant="primary" type="submit">
                                 <i className="bi bi-search"></i>
                             </Button>
                         </Col>
 
-                        <Col xs='auto'>
+                        <Col xs="auto">
                             <Button variant="primary" onClick={() => setShowSidebar(!showSidebar)}>
                                 <i className="bi bi-patch-question-fill"></i>
                             </Button>
@@ -178,78 +185,104 @@ export const Analytics = () => {
                     </Row>
                 </Form>
 
+
                 {loading && <Spinner animation="border" variant="primary" role="status"></Spinner>}
-                {error && <p style={{ color: 'red' }}>{error}</p>}
+                {error &&
+                    <>
+                        <p style={{ color: 'red' }}>
+                            Something went wrong ({error}).
+                            <br />
+                            Check the console for more info.
+                        </p>
+                        <p>
+                            Make sure keywords are <b>not wrapped in quotes</b>.
+                            <br />
+                            Make sure log levels, dates and words/phrases <b>are wrapped in quotes</b>.
+                            <br />
+                            Make sure you don't have dangling parentheses.
+                            <br />
+                        </p>
+                    </>
+                }
 
                 {logs !== null && (
                     <>
-                        <div className="d-flex flex-wrap gap-3 mt-3 align-items-start">
-                            {/* Pagination */}
-                            <div>
-                                {renderPagination()}
+                        {logs.hits.length === 0 ? (
+                            <div className="mt-4 text-muted">
+                                <h5>No results found</h5>
+                                <p>Try adjusting your query or filters to find matching logs.</p>
                             </div>
+                        ) : (
+                            <>
+                                <div className="d-flex flex-wrap gap-3 mt-3 align-items-start">
+                                    {/* Pagination */}
+                                    <div>{renderPagination()}</div>
 
-                            {/* Page size dropdown with inline label */}
-                            <div className="d-flex align-items-center gap-2">
-                                <label htmlFor="pageSizeSelect" className="mb-0">Rows per page:</label>
-                                <Form.Select
-                                    id="pageSizeSelect"
-                                    value={pageSize}
-                                    onChange={(e) => {
-                                        setPageSize(Number(e.target.value));
-                                        setPageNumber(1);
-                                    }}
-                                    style={{ width: '100px' }}
-                                >
-                                    {[5, 10, 25, 50, 100].map((size) => (
-                                        <option key={size} value={size}>
-                                            {size}
-                                        </option>
-                                    ))}
-                                </Form.Select>
-                            </div>
-                        </div>
+                                    {/* Page size dropdown with inline label */}
+                                    <div className="d-flex align-items-center gap-2">
+                                        <label htmlFor="pageSizeSelect" className="mb-0">Rows per page:</label>
+                                        <Form.Select
+                                            id="pageSizeSelect"
+                                            value={pageSize}
+                                            onChange={(e) => {
+                                                setPageSize(Number(e.target.value));
+                                                setPageNumber(1);
+                                            }}
+                                            style={{ width: '100px' }}
+                                        >
+                                            {[5, 10, 25, 50, 100].map((size) => (
+                                                <option key={size} value={size}>{size}</option>
+                                            ))}
+                                        </Form.Select>
+                                    </div>
+                                </div>
 
-                        {/* Log count */}
-                        <div>
-                            Showing <strong>{logs.hits.length}</strong> of <strong>{logs.info.total_hits}</strong> logs
-                        </div>
+                                {/* Log count */}
+                                <div>
+                                    Showing <strong>{logs.hits.length}</strong> of <strong>{logs.info.total_hits}</strong> results on
+                                    page <strong>{logs.info.page}</strong> of <strong>{logs.info.total_pages}</strong>
+                                </div>
 
-                        <div style={{ maxHeight: '600px', overflowY: 'auto', overflowX: 'auto' }}>
-                            <Table striped bordered hover responsive style={{ tableLayout: 'fixed', width: '100%' }}>
-                                <thead>
-                                    <tr>
-                                        <th style={{ width: '200px', cursor: 'pointer' }} onClick={() => handleSort('date_time')}>
-                                            Timestamp {getSortIcon('date_time')}
-                                        </th>
-                                        <th style={{ width: '120px', cursor: 'pointer' }} onClick={() => handleSort('log_level')}>
-                                            Level {getSortIcon('log_level')}
-                                        </th>
-                                        <th style={{ width: '600px' }}>Message</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {logs.hits.map((log, index) => (
-                                        <tr key={index}>
-                                            <td>{new Date(log.date_time).toLocaleString()}</td>
-                                            <td>
-                                                <span className={`badge bg-${getLevelVariant(log.level.toString())}`}>
-                                                    {log.level}
-                                                </span>
-                                            </td>
-                                            <td>{log.text}</td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </Table>
-                        </div>
+                                {/* Table */}
+                                <div style={{ maxHeight: '600px', overflowY: 'auto', overflowX: 'auto' }}>
+                                    <Table striped bordered hover responsive style={{ tableLayout: 'fixed', width: '100%' }}>
+                                        <thead>
+                                            <tr>
+                                                <th style={{ width: '200px', cursor: 'pointer' }} onClick={() => handleSort('date_time')}>
+                                                    Timestamp {getSortIcon('date_time')}
+                                                </th>
+                                                <th style={{ width: '120px', cursor: 'pointer' }} onClick={() => handleSort('log_level')}>
+                                                    Level {getSortIcon('log_level')}
+                                                </th>
+                                                <th style={{ width: '600px' }}>Message</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {logs.hits.map((log, index) => (
+                                                <tr key={index}>
+                                                    <td>{new Date(log.date_time).toLocaleString()}</td>
+                                                    <td>
+                                                        <span className={`badge bg-${getLevelVariant(log.level.toString())}`}>
+                                                            {log.level}
+                                                        </span>
+                                                    </td>
+                                                    <td>{log.text}</td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </Table>
+                                </div>
+                            </>
+                        )}
                     </>
                 )}
-            </div>
+            </div >
 
-            {showSidebar && (
-                <AnalyticsSidebar onClose={() => setShowSidebar(false)} />
-            )}
-        </div>
+            {
+                showSidebar && (
+                    <AnalyticsSidebar onClose={() => setShowSidebar(false)} />
+                )
+            }
+        </div >
     );
 };

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { AxiosError, AxiosResponse } from 'axios';
+import { LogQueryDTO, LogsService } from '../api/logs.api';
+
+export const Analytics = () => {
+    const [query, setQuery] = useState('log_level == "info"');
+    const [pageNumber, setPageNumber] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const [sortBy, setSortBy] = useState('timestamp');
+    const [sortAscending, setSortAscending] = useState(true);
+    const [logs, setLogs] = useState<LogQueryDTO | null>(null);
+    // const [totalResults, setTotalResults] = useState(0);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    const handleSearch = async () => {
+        setLoading(true);
+        setError('');
+
+        LogsService.Search(query, pageNumber, pageSize, sortBy, sortAscending).then((res: AxiosResponse<LogQueryDTO>) => {
+            console.log(res.data);
+            setLogs(res.data);
+        }).catch((err: AxiosError) => {
+            setError(err.message || 'Failed to fetch logs');
+            setLogs(null);
+        }).finally(() => {
+            setLoading(false);
+        });
+
+    };
+
+    return (
+        <div style={{ padding: '2rem' }}>
+            <h2>Log Search</h2>
+            <div style={{ marginBottom: '1rem' }}>
+                <input
+                    type="text"
+                    placeholder="Search query"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                />
+                <input
+                    type="number"
+                    placeholder="Page number"
+                    value={pageNumber}
+                    onChange={(e) => setPageNumber(Number(e.target.value))}
+                />
+                <input
+                    type="number"
+                    placeholder="Page size"
+                    value={pageSize}
+                    onChange={(e) => setPageSize(Number(e.target.value))}
+                />
+                <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+                    <option value="date_time">Timestamp</option>
+                    <option value="log_level">Level</option>
+                </select>
+                <label>
+                    <input
+                        type="checkbox"
+                        checked={sortAscending}
+                        onChange={(e) => setSortAscending(e.target.checked)}
+                    />
+                    Sort Ascending
+                </label>
+                <button onClick={handleSearch}>Search</button>
+            </div>
+
+            {loading && <p>Loading...</p>}
+            {error && <p style={{ color: 'red' }}>{error}</p>}
+
+            {logs !== null &&
+                <span>
+
+                    <ul>
+                        {logs.hits.map((log, index) => (
+                            <li key={index}>
+                                <strong>{log.date_time}</strong> [{log.level}] - {log.text}
+                            </li>
+                        ))}
+                    </ul>
+
+                    <div>
+                        Page {logs.info.page} of {logs.info.total_pages} <br />
+                        Showing {logs.info.page_size} of {logs.info.total_hits} logs <br />
+                    </div>
+
+                </span>
+            }
+        </div >
+    );
+};

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -6,9 +6,12 @@ import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import { Row, Col, Table } from 'react-bootstrap';
 import { Pagination } from 'react-bootstrap';
+import "./Analytics.css";
+import ReactMarkdown from 'react-markdown';
+import { AnalyticsSidebar } from '../components/AnalyticsSidebar';
 
 export const Analytics = () => {
-    const [query, setQuery] = useState('log_level == "info"');
+    const [query, setQuery] = useState("");
     const [pageNumber, setPageNumber] = useState(1);
     const [pageSize, setPageSize] = useState(10);
     const [sortBy, setSortBy] = useState('date_time');
@@ -16,6 +19,7 @@ export const Analytics = () => {
     const [logs, setLogs] = useState<LogQueryDTO | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');
+    const [showSidebar, setShowSidebar] = useState<boolean>(false);
 
     const getSortIcon = (column: string) => {
         if (sortBy !== column) return null;
@@ -38,6 +42,11 @@ export const Analytics = () => {
     };
 
     const handleSearch = async () => {
+        if (query == "") {
+            setLogs(null);
+            setError('');
+            return;
+        }
         if (logs === null) {
             setLoading(true);
         }
@@ -135,99 +144,111 @@ export const Analytics = () => {
     };
 
     return (
-        <div style={{ padding: '2rem' }}>
-            <h2 className="text-center">
-                <i className="bi-graph-up"></i> Log Search
-            </h2>
+        <div className="page-container" style={{ padding: '2rem' }}>
+            <div className="main-content">
+                <h2 className="text-center">
+                    <i className="bi-graph-up"></i> Log Search
+                </h2>
 
-            <Form className="mb-3">
-                <Row className="g-3 align-items-end">
-                    <Col xs={9} md={11}>
-                        <Form.Group controlId="searchQuery">
-                            <Form.Label>Search Query</Form.Label>
-                            <Form.Control
-                                type="text"
-                                placeholder="Enter search query"
-                                value={query}
-                                onChange={(e) => setQuery(e.target.value)}
-                            />
-                        </Form.Group>
-                    </Col>
+                <Form className="mb-3">
+                    <Row className="g-3 align-items-end">
+                        <Col xs={0}>
+                            <Form.Group controlId="searchQuery">
+                                <Form.Label>Search Query</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    placeholder="Enter search query"
+                                    value={query}
+                                    onChange={(e) => setQuery(e.target.value)}
+                                />
+                            </Form.Group>
+                        </Col>
 
-                    <Col xs={3} md={1}>
-                        <Button variant="primary" onClick={handleSearch} className="w-100">
-                            Search
-                        </Button>
-                    </Col>
-                </Row>
-            </Form>
+                        <Col xs='auto'>
+                            <Button variant="primary" onClick={handleSearch}>
+                                <i className="bi bi-search"></i>
+                            </Button>
+                        </Col>
 
-            {loading && <Spinner animation="border" variant="primary" role="status"></Spinner>}
-            {error && <p style={{ color: 'red' }}>{error}</p>}
+                        <Col xs='auto'>
+                            <Button variant="primary" onClick={() => setShowSidebar(!showSidebar)}>
+                                <i className="bi bi-patch-question-fill"></i>
+                            </Button>
+                        </Col>
+                    </Row>
+                </Form>
 
-            {logs !== null && (
-                <>
-                    <div className="d-flex flex-wrap gap-3 mt-3 align-items-start">
-                        {/* Pagination */}
+                {loading && <Spinner animation="border" variant="primary" role="status"></Spinner>}
+                {error && <p style={{ color: 'red' }}>{error}</p>}
+
+                {logs !== null && (
+                    <>
+                        <div className="d-flex flex-wrap gap-3 mt-3 align-items-start">
+                            {/* Pagination */}
+                            <div>
+                                {renderPagination()}
+                            </div>
+
+                            {/* Page size dropdown with inline label */}
+                            <div className="d-flex align-items-center gap-2">
+                                <label htmlFor="pageSizeSelect" className="mb-0">Rows per page:</label>
+                                <Form.Select
+                                    id="pageSizeSelect"
+                                    value={pageSize}
+                                    onChange={(e) => {
+                                        setPageSize(Number(e.target.value));
+                                        setPageNumber(1);
+                                    }}
+                                    style={{ width: '100px' }}
+                                >
+                                    {[5, 10, 25, 50, 100].map((size) => (
+                                        <option key={size} value={size}>
+                                            {size}
+                                        </option>
+                                    ))}
+                                </Form.Select>
+                            </div>
+                        </div>
+
+                        {/* Log count */}
                         <div>
-                            {renderPagination()}
+                            Showing <strong>{logs.hits.length}</strong> of <strong>{logs.info.total_hits}</strong> logs
                         </div>
 
-                        {/* Page size dropdown with inline label */}
-                        <div className="d-flex align-items-center gap-2">
-                            <label htmlFor="pageSizeSelect" className="mb-0">Rows per page:</label>
-                            <Form.Select
-                                id="pageSizeSelect"
-                                value={pageSize}
-                                onChange={(e) => {
-                                    setPageSize(Number(e.target.value));
-                                    setPageNumber(1);
-                                }}
-                                style={{ width: '100px' }}
-                            >
-                                {[5, 10, 25, 50, 100].map((size) => (
-                                    <option key={size} value={size}>
-                                        {size}
-                                    </option>
-                                ))}
-                            </Form.Select>
-                        </div>
-                    </div>
-
-                    {/* Log count */}
-                    <div>
-                        Showing <strong>{logs.hits.length}</strong> of <strong>{logs.info.total_hits}</strong> logs
-                    </div>
-
-                    <div style={{ maxHeight: '600px', overflowY: 'auto', overflowX: 'auto' }}>
-                        <Table striped bordered hover responsive style={{ tableLayout: 'fixed', width: '100%' }}>
-                            <thead>
-                                <tr>
-                                    <th style={{ width: '200px', cursor: 'pointer' }} onClick={() => handleSort('date_time')}>
-                                        Timestamp {getSortIcon('date_time')}
-                                    </th>
-                                    <th style={{ width: '120px', cursor: 'pointer' }} onClick={() => handleSort('log_level')}>
-                                        Level {getSortIcon('log_level')}
-                                    </th>
-                                    <th style={{ width: '600px' }}>Message</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {logs.hits.map((log, index) => (
-                                    <tr key={index}>
-                                        <td>{new Date(log.date_time).toLocaleString()}</td>
-                                        <td>
-                                            <span className={`badge bg-${getLevelVariant(log.level.toString())}`}>
-                                                {log.level}
-                                            </span>
-                                        </td>
-                                        <td>{log.text}</td>
+                        <div style={{ maxHeight: '600px', overflowY: 'auto', overflowX: 'auto' }}>
+                            <Table striped bordered hover responsive style={{ tableLayout: 'fixed', width: '100%' }}>
+                                <thead>
+                                    <tr>
+                                        <th style={{ width: '200px', cursor: 'pointer' }} onClick={() => handleSort('date_time')}>
+                                            Timestamp {getSortIcon('date_time')}
+                                        </th>
+                                        <th style={{ width: '120px', cursor: 'pointer' }} onClick={() => handleSort('log_level')}>
+                                            Level {getSortIcon('log_level')}
+                                        </th>
+                                        <th style={{ width: '600px' }}>Message</th>
                                     </tr>
-                                ))}
-                            </tbody>
-                        </Table>
-                    </div>
-                </>
+                                </thead>
+                                <tbody>
+                                    {logs.hits.map((log, index) => (
+                                        <tr key={index}>
+                                            <td>{new Date(log.date_time).toLocaleString()}</td>
+                                            <td>
+                                                <span className={`badge bg-${getLevelVariant(log.level.toString())}`}>
+                                                    {log.level}
+                                                </span>
+                                            </td>
+                                            <td>{log.text}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </div>
+                    </>
+                )}
+            </div>
+
+            {showSidebar && (
+                <AnalyticsSidebar onClose={() => setShowSidebar(false)} />
             )}
         </div>
     );

--- a/log_collector/log_collector.py
+++ b/log_collector/log_collector.py
@@ -94,6 +94,11 @@ class FileChangeHandler(FileSystemEventHandler):
     def on_modified(self, event):
         if event.src_path == self.file_path:
             current_size = os.path.getsize(self.file_path)
+
+            if self.previous_size > current_size:
+                logging.warning(f"Irregularity in log size: want ({self.previous_size}) but ({current_size}). Rewinding...")
+                current_size = self.previous_size
+
             if current_size > self.previous_size:
                 with open(self.file_path, 'r') as file:
                     file.seek(self.previous_size)

--- a/queryman.py
+++ b/queryman.py
@@ -52,7 +52,7 @@ condition:
     field=ID op=Op value=STRING
 ;
 
-Op: '==' | '!=' | '~=' | '>=' | '>' | '<=' | '<';
+Op: '==' | '!=' | '~=' | '~~=' | '>=' | '>' | '<=' | '<';
 '''
 
 meta = metamodel_from_str(query_grammar)
@@ -67,6 +67,8 @@ def to_query(node):
             return Q('bool', must_not=[Q('term', **{field: val})])
         if op == '~=':
             return Q('match', **{field: val})
+        if op == '~~=':
+            return Q('match_phrase', **{field: val})
         if op in ['>', '<', '>=', '<=']:
             op_map = {
                 '>': 'gt', 
@@ -114,7 +116,7 @@ def search(query: Q, page_number: int, page_size: int, sort_by: str, sort_ascend
         page_size = 1
 
     sort_str = f"{'' if sort_ascending else '-'}{sort_by}"
-    if sort_by not in ['date_time', 'log_level', 'text_content']:
+    if sort_by not in ['date_time', 'log_level']: # But not 'text_content' because text is not optimized for aggregation and sorting.
         sort_str = None
 
     print(sort_by, sort_str)
@@ -166,11 +168,11 @@ def doit(query_string: str, page_num: int, page_size: int, sort_by: str, sort_as
 
 
 QUERY = '(log_level == "error" or log_level == "info") and (not text_content ~= "ghuyueyeuyeuriey7327983 2")'
-QUERY = 'date_time > "2025-07-16" and date_time <= "2030-01-01"'
+QUERY = 'log_level == "error" or log_level == "info"'
 
 PAGE_NUM = 1
 PAGE_SIZE = 5
-SORT_BY = 'date_time' # 'date_time', 'log_level', 'text_content', ''
-SORT_ASC = False
+SORT_BY = 'log_level' # 'date_time', 'log_level', ''
+SORT_ASC = True
 
 doit(QUERY, PAGE_NUM, PAGE_SIZE, SORT_BY, SORT_ASC)

--- a/queryman.py
+++ b/queryman.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 from enum import Enum
 from elasticsearch_dsl import Document, Text, Date, Keyword, Search, Q, connections
 
@@ -17,23 +18,32 @@ class Event(Document):
     class Index:
         name = 'events'
 
-def search():
+def search(page_number: int, page_size: int, sort_by: str, sort_ascending: bool) -> List:
     hostname = os.getenv("ES_HOST", "localhost:9200")
     connections.create_connection(hosts=[f"http://{hostname}"])
 
+    if page_number < 1:
+        page_number = 1
+    if page_size < 1:
+        page_size = 1
+
+    sort_str = f"{'' if sort_ascending else '-'}{sort_by}"
+    if sort_by not in ['date_time', 'log_level', 'text_content']:
+        sort_str = None
+
+    pag_start = (page_number - 1) * page_size
+    pag_end = pag_start + page_size
+
     s = Search(index=Event.Index.name)
+    if sort_str is not None:
+        s = s.sort(sort_str)
+    s = s[pag_start:pag_end]
 
-    q = Q('term', log_level=EventLevel.Error.value)
-
-    q = Q('range', date_time={
-              "gte": "2025-07-10",
-              "lt": "2025-07-31"
-    })
 
     q = Q('bool',
         must = [
-            #Q("match", text_content="wants"),
-            Q('term', log_level=EventLevel.Error.value),
+            Q("match", text_content="wants"),
+            #Q('term', log_level=EventLevel.Error.value),
             Q('range', date_time={"gte": "2025-06-10"}),
         ]
     )
@@ -41,7 +51,8 @@ def search():
     s = s.query(q)
     response = s.execute()
 
-    for hit in response:
-        print(f"[{hit.date_time}] [{hit.log_level}] {hit.text_content}")
+    return response
 
-search()
+res = search(0, 5, 'date_time', True)
+for hit in res:
+    print(f"[{hit.date_time}] [{hit.log_level}] {hit.text_content}")

--- a/queryman.py
+++ b/queryman.py
@@ -1,0 +1,47 @@
+import os
+from enum import Enum
+from elasticsearch_dsl import Document, Text, Date, Keyword, Search, Q, connections
+
+
+class EventLevel(Enum):
+    Debug = "debug"
+    Info = "info"
+    Warning = "warning"
+    Error = "error"
+
+class Event(Document):
+    date_time = Date()
+    log_level = Keyword()
+    text_content = Text()
+
+    class Index:
+        name = 'events'
+
+def search():
+    hostname = os.getenv("ES_HOST", "localhost:9200")
+    connections.create_connection(hosts=[f"http://{hostname}"])
+
+    s = Search(index=Event.Index.name)
+
+    q = Q('term', log_level=EventLevel.Error.value)
+
+    q = Q('range', date_time={
+              "gte": "2025-07-10",
+              "lt": "2025-07-31"
+    })
+
+    q = Q('bool',
+        must = [
+            #Q("match", text_content="wants"),
+            Q('term', log_level=EventLevel.Error.value),
+            Q('range', date_time={"gte": "2025-06-10"}),
+        ]
+    )
+    
+    s = s.query(q)
+    response = s.execute()
+
+    for hit in response:
+        print(f"[{hit.date_time}] [{hit.log_level}] {hit.text_content}")
+
+search()

--- a/queryman.py
+++ b/queryman.py
@@ -2,7 +2,7 @@ import os
 from typing import List
 from enum import Enum
 from elasticsearch_dsl import Document, Text, Date, Keyword, Search, Q, connections
-
+import math
 
 class EventLevel(Enum):
     Debug = "debug"
@@ -53,6 +53,15 @@ def search(page_number: int, page_size: int, sort_by: str, sort_ascending: bool)
 
     return response
 
-res = search(0, 5, 'date_time', True)
+PAGE_NUM = 1
+PAGE_SIZE = 40
+
+res = search(PAGE_NUM, PAGE_SIZE, 'date_time', True)
+total_hits = res.hits.total.value
+total_pages = math.ceil(total_hits / PAGE_SIZE)
+
 for hit in res:
     print(f"[{hit.date_time}] [{hit.log_level}] {hit.text_content}")
+
+print()
+print(f"Page ({PAGE_NUM} / {total_pages}) [{PAGE_SIZE} items of {total_hits}]")

--- a/queryman.py
+++ b/queryman.py
@@ -1,8 +1,11 @@
 import os
 from typing import List
 from enum import Enum
-from elasticsearch_dsl import Document, Text, Date, Keyword, Search, Q, connections
 import math
+from elasticsearch_dsl import Document, Text, Date, Keyword, Search, Q, connections
+from textx import metamodel_from_str
+
+####################################################### MODEL
 
 class EventLevel(Enum):
     Debug = "debug"
@@ -18,7 +21,90 @@ class Event(Document):
     class Index:
         name = 'events'
 
-def search(page_number: int, page_size: int, sort_by: str, sort_ascending: bool) -> List:
+####################################################### GRAMMAR
+
+query_grammar = r'''
+Model: expr ;
+
+expr: or_expr ;
+
+or_expr:
+    left=and_expr
+    ( op='or' right=and_expr )*
+;
+
+and_expr:
+    left=not_expr
+    ( op='and' right=not_expr )*
+;
+
+not_expr:
+    op='not' right=not_expr
+  | atom=atom
+;
+
+atom:
+    condition
+  | '(' expr ')'
+;
+
+condition:
+    field=ID op=Op value=STRING
+;
+
+Op: '==' | '!=' | '~=' | '>=' | '>' | '<=' | '<';
+'''
+
+meta = metamodel_from_str(query_grammar)
+
+def to_query(node):
+    # 1) Leaf conditions
+    if hasattr(node, 'op') and hasattr(node, 'field'):
+        field, op, val = node.field, node.op, node.value.strip('"')
+        if op == '==':
+            return Q('term', **{field: val})
+        if op == '!=':
+            return Q('bool', must_not=[Q('term', **{field: val})])
+        if op == '~=':
+            return Q('match', **{field: val})
+        if op in ['>', '<', '>=', '<=']:
+            op_map = {
+                '>': 'gt', 
+                '<': 'lt', 
+                '>=': 'gte', 
+                '<=': 'lte'
+            }
+            return Q('range', **{field: {op_map[op]: val}})
+
+    # 2) Parenthesized subexpression
+    if hasattr(node, 'expr'):
+        return to_query(node.expr)
+
+    # 3) NOT expressions
+    if getattr(node, 'op', None) == 'not' and hasattr(node, 'right'):
+        inner_q = to_query(node.right)
+        return Q('bool', must_not=[inner_q])
+
+    # 4) AND / OR chains
+    if hasattr(node, 'left') and hasattr(node, 'op'):
+        q = to_query(node.left)
+        for operator, right_node in zip(node.op, node.right):
+            next_q = to_query(right_node)
+            if operator == 'and':
+                q = Q('bool', must=[q, next_q])
+            else:  # 'or'
+                q = Q('bool', should=[q, next_q])
+        return q
+
+    # 5) Atom wrapper
+    if hasattr(node, 'atom'):
+        return to_query(node.atom)
+
+    return None
+
+####################################################### QUERY BUILDER
+
+def search(query: Q, page_number: int, page_size: int, sort_by: str, sort_ascending: bool) -> List:
     hostname = os.getenv("ES_HOST", "localhost:9200")
     connections.create_connection(hosts=[f"http://{hostname}"])
 
@@ -31,6 +117,8 @@ def search(page_number: int, page_size: int, sort_by: str, sort_ascending: bool)
     if sort_by not in ['date_time', 'log_level', 'text_content']:
         sort_str = None
 
+    print(sort_by, sort_str)
+
     pag_start = (page_number - 1) * page_size
     pag_end = pag_start + page_size
 
@@ -40,31 +128,49 @@ def search(page_number: int, page_size: int, sort_by: str, sort_ascending: bool)
     s = s[pag_start:pag_end]
 
 
-    q = Q('bool',
-        must = [
-            Q("match", text_content="wants"),
-            #Q('term', log_level=EventLevel.Error.value),
-            Q('range', date_time={"gte": "2025-07-16T07:08:18"}),
-        ],
-        must_not = [
-            Q("match", text_content="Retrying in 5")
-        ]
-    )
+    # q = Q('bool',
+    #     must = [
+    #         Q("match", text_content="wants"),
+    #         #Q('term', log_level=EventLevel.Error.value),
+    #         Q('range', date_time={"gte": "2025-07-16T07:08:18"}),
+    #     ],
+    #     must_not = [
+    #         Q("match", text_content="Retrying in 5")
+    #     ]
+    # )
     
-    s = s.query(q)
+    s = s.query(query)
     response = s.execute()
 
     return response
 
+####################################################### "API"
+
+
+def doit(query_string: str, page_num: int, page_size: int, sort_by: str, sort_asc: bool):
+    model = meta.model_from_str(query_string)
+    query = to_query(model)
+
+    print(query)
+
+    res = search(query, page_num, page_size, sort_by, sort_asc)
+    total_hits = res.hits.total.value
+    total_pages = math.ceil(total_hits / page_size)
+
+    for hit in res:
+        print(f"[{hit.date_time}] [{hit.log_level}] {hit.text_content}")
+
+    print()
+    print(f"Page ({page_num} / {total_pages}) [{page_size} items of {total_hits}]")
+
+
+
+QUERY = '(log_level == "error" or log_level == "info") and (not text_content ~= "ghuyueyeuyeuriey7327983 2")'
+QUERY = 'date_time > "2025-07-16" and date_time <= "2030-01-01"'
+
 PAGE_NUM = 1
-PAGE_SIZE = 10
+PAGE_SIZE = 5
+SORT_BY = 'date_time' # 'date_time', 'log_level', 'text_content', ''
+SORT_ASC = False
 
-res = search(PAGE_NUM, PAGE_SIZE, 'date_time', True)
-total_hits = res.hits.total.value
-total_pages = math.ceil(total_hits / PAGE_SIZE)
-
-for hit in res:
-    print(f"[{hit.date_time}] [{hit.log_level}] {hit.text_content}")
-
-print()
-print(f"Page ({PAGE_NUM} / {total_pages}) [{PAGE_SIZE} items of {total_hits}]")
+doit(QUERY, PAGE_NUM, PAGE_SIZE, SORT_BY, SORT_ASC)

--- a/queryman.py
+++ b/queryman.py
@@ -119,8 +119,6 @@ def search(query: Q, page_number: int, page_size: int, sort_by: str, sort_ascend
     if sort_by not in ['date_time', 'log_level']: # But not 'text_content' because text is not optimized for aggregation and sorting.
         sort_str = None
 
-    print(sort_by, sort_str)
-
     pag_start = (page_number - 1) * page_size
     pag_end = pag_start + page_size
 
@@ -129,18 +127,6 @@ def search(query: Q, page_number: int, page_size: int, sort_by: str, sort_ascend
         s = s.sort(sort_str)
     s = s[pag_start:pag_end]
 
-
-    # q = Q('bool',
-    #     must = [
-    #         Q("match", text_content="wants"),
-    #         #Q('term', log_level=EventLevel.Error.value),
-    #         Q('range', date_time={"gte": "2025-07-16T07:08:18"}),
-    #     ],
-    #     must_not = [
-    #         Q("match", text_content="Retrying in 5")
-    #     ]
-    # )
-    
     s = s.query(query)
     response = s.execute()
 
@@ -149,30 +135,75 @@ def search(query: Q, page_number: int, page_size: int, sort_by: str, sort_ascend
 ####################################################### "API"
 
 
-def doit(query_string: str, page_num: int, page_size: int, sort_by: str, sort_asc: bool):
+def doit(query_string: str, page_num: int, page_size: int, sort_by: str, sort_asc: bool) -> dict:
     model = meta.model_from_str(query_string)
     query = to_query(model)
-
-    print(query)
 
     res = search(query, page_num, page_size, sort_by, sort_asc)
     total_hits = res.hits.total.value
     total_pages = math.ceil(total_hits / page_size)
 
+    result = {}
+    result["info"] = {
+        "page": page_num,
+        "page_size": page_size,
+        "total_pages": total_pages,
+        "total_hits": total_hits,
+    }
+    result["hits"] = []
     for hit in res:
-        print(f"[{hit.date_time}] [{hit.log_level}] {hit.text_content}")
+        h = {
+            "date_time": hit.date_time,
+            "level": hit.log_level,
+            "text": hit.text_content
+        }
+        result["hits"].append(h)
+    return result
+
+def printme(result: dict):
+    for hit in result["hits"]:
+        print(f"[{hit['date_time']}] [{hit['level']}] {hit['text']}")
 
     print()
-    print(f"Page ({page_num} / {total_pages}) [{page_size} items of {total_hits}]")
+    print(f"Page ({result['info']['page']} / {result['info']['total_pages']}) [{result['info']['page_size']} items of {result['info']['total_hits']}")
 
 
+def local():     
+    QUERY = '(log_level == "error" or log_level == "info") and (not text_content ~= "ghuyueyeuyeuriey7327983 2")'
+    QUERY = 'log_level == "error" or log_level == "info"'
 
-QUERY = '(log_level == "error" or log_level == "info") and (not text_content ~= "ghuyueyeuyeuriey7327983 2")'
-QUERY = 'log_level == "error" or log_level == "info"'
+    PAGE_NUM = 1
+    PAGE_SIZE = 5
+    SORT_BY = 'log_level' # 'date_time', 'log_level', ''
+    SORT_ASC = True
 
-PAGE_NUM = 1
-PAGE_SIZE = 5
-SORT_BY = 'log_level' # 'date_time', 'log_level', ''
-SORT_ASC = True
+    res = doit(QUERY, PAGE_NUM, PAGE_SIZE, SORT_BY, SORT_ASC)
+    printme(res)
 
-doit(QUERY, PAGE_NUM, PAGE_SIZE, SORT_BY, SORT_ASC)
+
+#################### Temp flask server.
+
+from flask import Flask, request, jsonify
+from operator import itemgetter
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+
+@app.route('/search_logs', methods=['GET'])
+def search_logs():
+    # Get query parameters
+    query = request.args.get('query', '', type=str)
+    page_number = request.args.get('page_number', 1, type=int)
+    page_size = request.args.get('page_size', 10, type=int)
+    sort_by = request.args.get('sort_by', 'text_content', type=str)
+    sort_ascending = request.args.get('sort_ascending', 'true').lower() == 'true'
+
+    res = doit(query, page_number, page_size, sort_by, sort_ascending)
+    printme(res)
+
+    return jsonify(res)
+
+if __name__ == '__main__':
+    app.run(host='localhost', port=8068)

--- a/queryman.py
+++ b/queryman.py
@@ -44,7 +44,10 @@ def search(page_number: int, page_size: int, sort_by: str, sort_ascending: bool)
         must = [
             Q("match", text_content="wants"),
             #Q('term', log_level=EventLevel.Error.value),
-            Q('range', date_time={"gte": "2025-06-10"}),
+            Q('range', date_time={"gte": "2025-07-16T07:08:18"}),
+        ],
+        must_not = [
+            Q("match", text_content="Retrying in 5")
         ]
     )
     
@@ -54,7 +57,7 @@ def search(page_number: int, page_size: int, sort_by: str, sort_ascending: bool)
     return response
 
 PAGE_NUM = 1
-PAGE_SIZE = 40
+PAGE_SIZE = 10
 
 res = search(PAGE_NUM, PAGE_SIZE, 'date_time', True)
 total_hits = res.hits.total.value

--- a/server/app/api/events/event_controller.py
+++ b/server/app/api/events/event_controller.py
@@ -1,20 +1,14 @@
 from typing import List
 from fastapi import APIRouter, Depends
 
-from app.api.events.event_dto import EventDTO
+from app.api.events.event_dto import EventDTO, LogsResultDTO
 from app.api.events.event_service import EventService, get_event_service
 from app.api.events.event_model import EventLevel
 from app.api.config.exception_handler import InvalidInputException
 
 router = APIRouter(prefix="/events", tags=["events"])
 
-@router.get("/", response_model=List[EventDTO], status_code=200, summary="Something...")
-async def search_events_route(log_level: str, start_date: str = None, end_date: str = None, event_service: EventService = Depends(get_event_service)):
-    try:
-        log_level = EventLevel(log_level)
-    except ValueError:
-        possible_values = [lvl.value for lvl in EventLevel]
-        raise InvalidInputException(f"Unknown log level '{log_level}', supported values are {possible_values}")
-
-    events = event_service.search(log_level, start_date, end_date)
-    return events
+@router.get("/", response_model=LogsResultDTO, status_code=200, summary="Query for analytics")
+async def query_analytics(query: str, page_number: int, page_size: int, sort_by: str, sort_ascending: bool, event_service: EventService = Depends(get_event_service)):
+    result = event_service.query(query, page_number, page_size, sort_by, sort_ascending)
+    return result

--- a/server/app/api/events/event_dto.py
+++ b/server/app/api/events/event_dto.py
@@ -1,7 +1,24 @@
 from pydantic import BaseModel
 from datetime import datetime
+from typing import List
 
 class EventDTO(BaseModel):
     date_time: datetime
     log_level: str
     text_content: str
+
+
+class LogDTO(BaseModel):
+    date_time: datetime
+    level: str
+    text: str
+
+class LogsResultInfoDTO(BaseModel):
+    page: int
+    page_size: int
+    total_pages: int
+    total_hits: int
+
+class LogsResultDTO(BaseModel):
+    hits: List[LogDTO]
+    info: LogsResultInfoDTO

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -146,7 +146,7 @@ class EventService:
 
         return response
 
-    def query(self, query_string: str, page_num: int, page_size: int, sort_by: str, sort_asc: bool) -> dict:
+    def query(self, query_string: str, page_num: int, page_size: int, sort_by: str, sort_asc: bool) -> LogsResultDTO:
         """
         High-level method for submitting a query.
         """

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -1,15 +1,49 @@
 import logging
+import math
 import os
 from typing import Type
 from app.api.events.event_model import Event, EventLevel
-from elasticsearch_dsl import Search
+from app.api.events.event_dto import EventDTO, LogsResultDTO, LogDTO, LogsResultInfoDTO
 from datetime import datetime
 from app.api.config.logutil import LOGGER
-
+from elasticsearch_dsl import Document, Text, Date, Keyword, Search, Q, connections
+from textx import metamodel_from_str
 
 class EventService:
     def __init__(self):
-        ...
+        query_grammar = r'''
+            Model: expr ;
+
+            expr: or_expr ;
+
+            or_expr:
+                left=and_expr
+                ( op='or' right=and_expr )*
+            ;
+
+            and_expr:
+                left=not_expr
+                ( op='and' right=not_expr )*
+            ;
+
+            not_expr:
+                op='not' right=not_expr
+            | atom=atom
+            ;
+
+            atom:
+                condition
+            | '(' expr ')'
+            ;
+
+            condition:
+                field=ID op=Op value=STRING
+            ;
+
+            Op: '==' | '!=' | '~=' | '~~=' | '>=' | '>' | '<=' | '<';
+        '''
+
+        self.meta = metamodel_from_str(query_grammar)
 
     def log_read(self, user_id: int | None, entity_type: Type, entity_identifier: int | str):
         """
@@ -22,23 +56,6 @@ class EventService:
         """Generic log function."""
         LOGGER.log(self._event_level_to_log_level(log_level), text_content)
 
-    def search(self, log_level: EventLevel, start_date: str = None, end_date: str = None):
-        s = Search(index=Event.Index.name).filter("term", log_level=log_level.value)
-        
-        if start_date and end_date:
-            s = s.filter("range", date_time={"gte": start_date, "lte": end_date})
-        elif start_date:
-            s = s.filter("range", date_time={"gte": start_date})
-        elif end_date:
-            s = s.filter("range", date_time={"lte": end_date})
-        
-        response = s.execute()
-        return [{
-            "date_time": hit.date_time, 
-            "log_level": hit.log_level, 
-            "text_content": hit.text_content
-        } for hit in response]
-    
     def _event_level_to_log_level(self, event_level: EventLevel):
         if event_level == EventLevel.Debug:
             return logging.DEBUG
@@ -50,6 +67,114 @@ class EventService:
             return logging.ERROR
         else:
             raise ValueError(f"Unknown event level: {event_level}")
+        
+    def _to_query(self, node):
+        """
+        Convert TextX node to Elasticsearch-dsl Query object.
+        """
+
+        # 1) Leaf conditions
+        if hasattr(node, 'op') and hasattr(node, 'field'):
+            field, op, val = node.field, node.op, node.value.strip('"')
+            if op == '==':
+                return Q('term', **{field: val})
+            if op == '!=':
+                return Q('bool', must_not=[Q('term', **{field: val})])
+            if op == '~=':
+                return Q('match', **{field: val})
+            if op == '~~=':
+                return Q('match_phrase', **{field: val})
+            if op in ['>', '<', '>=', '<=']:
+                op_map = {
+                    '>': 'gt', 
+                    '<': 'lt', 
+                    '>=': 'gte', 
+                    '<=': 'lte'
+                }
+                return Q('range', **{field: {op_map[op]: val}})
+
+        # 2) Parenthesized subexpression
+        if hasattr(node, 'expr'):
+            return self._to_query(node.expr)
+
+        # 3) NOT expressions
+        if getattr(node, 'op', None) == 'not' and hasattr(node, 'right'):
+            inner_q = self._to_query(node.right)
+            return Q('bool', must_not=[inner_q])
+
+        # 4) AND / OR chains
+        if hasattr(node, 'left') and hasattr(node, 'op'):
+            q = self._to_query(node.left)
+            for operator, right_node in zip(node.op, node.right):
+                next_q = self._to_query(right_node)
+                if operator == 'and':
+                    q = Q('bool', must=[q, next_q])
+                else:  # 'or'
+                    q = Q('bool', should=[q, next_q])
+            return q
+
+        # 5) Atom wrapper
+        if hasattr(node, 'atom'):
+            return self._to_query(node.atom)
+
+        return None
+
+    def _query(self, query: Q, page_number: int, page_size: int, sort_by: str, sort_ascending: bool):
+        """
+        Low level query method which interacts with Elasticsearch.
+        """
+
+        if page_number < 1:
+            page_number = 1
+        if page_size < 1:
+            page_size = 1
+
+        sort_str = f"{'' if sort_ascending else '-'}{sort_by}"
+        if sort_by not in ['date_time', 'log_level']: # Not 'text_content' because text is not optimized for aggregation and sorting.
+            sort_str = None
+
+        pag_start = (page_number - 1) * page_size
+        pag_end = pag_start + page_size
+
+        s = Search(index=Event.Index.name)
+        if sort_str is not None:
+            s = s.sort(sort_str)
+        s = s[pag_start:pag_end]
+
+        s = s.query(query)
+        response = s.execute()
+
+        return response
+
+    def query(self, query_string: str, page_num: int, page_size: int, sort_by: str, sort_asc: bool) -> dict:
+        """
+        High-level method for submitting a query.
+        """
+
+        model = self.meta.model_from_str(query_string)
+        query = self._to_query(model)
+
+        res = self._query(query, page_num, page_size, sort_by, sort_asc)
+        total_hits = res.hits.total.value
+        total_pages = math.ceil(total_hits / page_size)
+
+        result_info  =LogsResultInfoDTO(
+            page=page_num,
+            page_size=page_size,
+            total_pages=total_pages,
+            total_hits=total_hits
+        )
+        hits = []
+        for hit in res:
+            h = LogDTO(
+                date_time=hit.date_time, 
+                level=hit.log_level, 
+                text=hit.text_content
+            )
+            hits.append(h)
+
+        result = LogsResultDTO(hits=hits, info=result_info)
+        return result
 
 
 def get_event_service() -> EventService:

--- a/server/app/tests/manual/queryman.py
+++ b/server/app/tests/manual/queryman.py
@@ -1,3 +1,15 @@
+"""
+This is a utility script for running ElasticSearch queries without starting the entire server.
+
+How to use:
+
+`python ./queryman.py`
+
+You need flask, elasticsearch_dsl amd textX
+
+This script and any of its functions should NOT be used by the program, but I'm keeping it here for now.
+"""
+
 import os
 from typing import List
 from enum import Enum

--- a/server/app/tests/test_z_events.py
+++ b/server/app/tests/test_z_events.py
@@ -4,14 +4,16 @@ from fastapi.testclient import TestClient
 from app.api.main import app
 from app.api.config.elasticsearch import wait_for_elasticsearch
 
-def test_temp___integration():
+def test_events___integration():
     with TestClient(app) as client:
         assert wait_for_elasticsearch()
 
-        def search_for_something(level: str):
-            response = client.get(f"/api/v1/events/?log_level={level}")
+        def search_for_something():
+            response = client.get(f"/api/v1/events/?query=date_time+%3C%3D+%222165-07-24%22&page_number=1&page_size=10&sort_by=date_time&sort_ascending=true")
             return response
         
-        res = search_for_something("info")
+        res = search_for_something()
         assert res.is_success
-        assert len(res.json()) > 0
+
+        hits = res.json()["hits"]
+        assert len(hits) >= 0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -17,3 +17,5 @@ httpx
 
 pillow
 elasticsearch-dsl
+
+textX==4.2.2


### PR DESCRIPTION
Closes #61 (and fixes bug related to #32).

> [**OLD**] **NOTE**: Because I was previously testing #62 and my database model changed, I didn't want to revert the changes to the DB schema. For this reason, I merged that branch's commits. That's why you can see those commits here. Once @hristinaina merges her branch to develop, these commits will go away. There's no conflict between these two PRs anyway, so you can safely ignore. So, this branch won't be merged until #62 is finished. Which is fine, since this feature is extremely isolated from the rest of the code.

This has been dealt with. There was one conflict when merging regarding the Navbar (I think it was the icons for the Repositories section) so make sure to check everything works regarding the Navbar!

While you are testing manually, if you're missing some logs, you can:
1) Click around the web app in search of user repositories and organizations. This triggers the "user XYZ wants ABC" event which gets logged.
2) You probably have logs from earlier in `logs/mocker-hub.log` if so, change the contents of `logs/mocker-hub.log.meta` to 0 and restart the `log-collector` container. That should trigger the log collector to re-send all of those logs to ES.

## Backend

I used `elasticsearch-dsl` to build a query which is sent to ES. The query is parsed from a string using TextX. The grammar was written with the aid of generative neural networks. I'm sorry.

It should work for all cases, but because I lack any theoretical knowledge of DSLs, beyond sort-of knowing how to read BNF, there may exist bugs.

Throughout most of my implementation of this feature, I wrote a separate python script that does all this work. That's `queryman.py`. It was easier to modify that instead of restarting the backend docker container image each time.

## Frontend

The web page looks like this:

<img width="1526" height="850" alt="image" src="https://github.com/user-attachments/assets/ae2fb97c-c22c-46e5-8423-8fd744774a67" />

Fully paginated, columns can be sorted (the text column can't because ElasticSearch is not optimized to do this). You don't have to memorize the grammar, you can click the help button which shows you some examples on how to use:

<img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/fdd6ead9-cacc-4947-9b59-7e3834d0ead3" />

I had to install a library that renders Markdown for this. I know I could've used HTML, but I didn't want to. Make sure to `npm i` before running.

## Tests

There are no unit tests for this. There isn't really a unit of code that was written for this. It's a basic `TextX -> ES Query`. Less than 1% of the code is our own. As for integration tests, doing anything that involves collecting logs is risky because of container syncing. I have a basic test that just confirms you can submit a query. If you have any ideas on how to do these tests, let me know.