### PR TITLE
fix: Reset role after password change signout

### DIFF
--- a/client/src/pages/UserPasswordChange.tsx
+++ b/client/src/pages/UserPasswordChange.tsx
@@ -3,8 +3,9 @@ import { Form, Button, Alert } from 'react-bootstrap';
 import { UserPasswordChangeDTO, UserService } from '../api/user.api';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
-import { clearJWT } from '../util/localstorage';
+import { clearJWT, setJWT } from '../util/localstorage';
 import { get_validation_error_readable } from '../util/http';
+import { useAuthStore } from '../util/store';
 
 export const UserPasswordChange = () => {
     let navigate = useNavigate();
@@ -14,6 +15,7 @@ export const UserPasswordChange = () => {
     const [confirmNewPassword, setConfirmNewPassword] = useState('');
     const [error, setError] = useState('');
     const isRequired = location.pathname === "/password-change-required";
+    const setRole = useAuthStore((state) => state.setRole);
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
@@ -29,6 +31,7 @@ export const UserPasswordChange = () => {
 
         UserService.ChangePassword(dto).then(() => {
             clearJWT();
+            setRole("");
             navigate("/login", { replace: true });
         }).catch((err: AxiosError) => {
             setError(get_validation_error_readable(err));


### PR DESCRIPTION
Closes #6 again.

When you change your password, you are signed out. But when that happens, the navbar wouldn't update (it should change to show login/sign up). The reason for that was that we didn't reset the user role after sign out. This only happens when you change your password, regular logout already had this.