### PR TITLE
Feature explore page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,6 +19,7 @@ import { OrganisationsOfUser } from './pages/OrgOfUser';
 import { ProfilePage } from './pages/ProfilePage';
 import { Analytics } from './pages/Analytics';
 import { UsersManagement } from './pages/UsersManagement';
+import { Explore } from './pages/Explore';
 
 // This function converts:
 //
@@ -67,6 +68,7 @@ function App() {
                     {/* Any role. */}
                     {authRoute("/password-change", ['user', 'admin', 'superadmin'], UserPasswordChange)}
                     {authRoute("/u/:username", ['user', 'admin', 'superadmin'], ProfilePage)}
+                    {authRoute("/explore", ['user', 'admin', 'superadmin'], Explore)}
 
                     {/* Protected routes. */}
                     {authRoute("/new", ['user', 'admin'], RepoCreate)}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -55,7 +55,7 @@ function App() {
                     {authRoute("/password-change-required", ['superadmin'], UserPasswordChange)}
 
                     {/* Anybody. */}
-                    {authRoute("/", [], Home)}
+                    {authRoute("/", [], Explore)}
                     {authRoute("/login", [], UserLogin)}
                     {authRoute("/logout", [], UserLogout)}
 
@@ -68,7 +68,6 @@ function App() {
                     {/* Any role. */}
                     {authRoute("/password-change", ['user', 'admin', 'superadmin'], UserPasswordChange)}
                     {authRoute("/u/:username", ['user', 'admin', 'superadmin'], ProfilePage)}
-                    {authRoute("/explore", ['user', 'admin', 'superadmin'], Explore)}
 
                     {/* Protected routes. */}
                     {authRoute("/new", ['user', 'admin'], RepoCreate)}

--- a/client/src/api/repo.api.ts
+++ b/client/src/api/repo.api.ts
@@ -36,6 +36,19 @@ export interface ReposOfUserDTO {
     organization_names: { [key: number]: string };
 }
 
+export interface RepositoryQueryInfoDTO {
+    page: number,
+    page_size: number,
+    total_pages: number,
+    total_hits: number,
+}
+
+export interface RepositoryQueryDTO {
+    hits: RepoDTO[],
+    info: RepositoryQueryInfoDTO,
+    organization_names: { [key: number]: string };
+}
+
 export interface RepoExtDTO extends RepoDTO {
     owner_name: string,
     org_name: string | null,
@@ -92,5 +105,19 @@ export class RepositoryService {
 
     static async DeleteRepo(repoId: number) : Promise<AxiosResponse<DeleteRepoResponseDTO>> {
         return await axiosInstance.delete(`/registry/repository/${repoId}`)
+    }
+
+    static async GetPublicRepositories(query: string, page: number, page_size: number, show_badge_official: boolean, show_badge_sponsored: boolean,
+         show_badge_verified: boolean): Promise<AxiosResponse<RepositoryQueryDTO>> {
+        return await axiosInstance.get(`/repositories/public/`, {
+            params: {
+                page_number: page,
+                page_size,
+                show_badge_official,
+                show_badge_sponsored,
+                show_badge_verified,
+                query
+            }
+        });
     }
 }

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -32,7 +32,7 @@ export function Navbar() {
                 {
                     role !== '' &&
                     <>
-                        <NavLink className={"navlink"} to="/explore" end><i className="bi bi-search"></i>Explore</NavLink>
+                        <NavLink className={"navlink"} to="/" end><i className="bi bi-search"></i>Explore</NavLink>
                         <NavLink className={"navlink"} to={`/u/${username}/repos`} end><i className="bi bi-boxes"></i>Repositories</NavLink>
                         <NavLink className={"navlink"} to={`/u/${username}/orgs`} end><i className="bi bi-building"></i>Organizations</NavLink>
                     </>

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -32,7 +32,7 @@ export function Navbar() {
                 {
                     role !== '' &&
                     <>
-                        <NavLink className={"navlink"} to="/." end><i className="bi bi-search"></i>Explore</NavLink>
+                        <NavLink className={"navlink"} to="/explore" end><i className="bi bi-search"></i>Explore</NavLink>
                         <NavLink className={"navlink"} to={`/u/${username}/repos`} end><i className="bi bi-boxes"></i>Repositories</NavLink>
                         <NavLink className={"navlink"} to={`/u/${username}/orgs`} end><i className="bi bi-building"></i>Organizations</NavLink>
                     </>

--- a/client/src/components/RepoPreview.tsx
+++ b/client/src/components/RepoPreview.tsx
@@ -72,7 +72,7 @@ export const RepoPreview: React.FC<{ repo: RepoDTO, orgNames: Map<number, string
                     {/* Description */}
                     {repo.desc && (
                         <Card.Text style={{ fontSize: '0.9rem' }}>
-                            {repo.desc}
+                            {repo.desc.length > 201 ? `${repo.desc.slice(0, 201)}...` : repo.desc}
                         </Card.Text>
                     )}
 

--- a/client/src/components/RepoPreview.tsx
+++ b/client/src/components/RepoPreview.tsx
@@ -70,11 +70,10 @@ export const RepoPreview: React.FC<{ repo: RepoDTO, orgNames: Map<number, string
                     )}
 
                     {/* Description */}
-                    {repo.desc && (
-                        <Card.Text style={{ fontSize: '0.9rem' }}>
-                            {repo.desc.length > 201 ? `${repo.desc.slice(0, 201)}...` : repo.desc}
-                        </Card.Text>
-                    )}
+                    <Card.Text
+                        style={{ fontSize: '0.9rem', minHeight: '3em', overflow: 'hidden' }}>
+                        {repo.desc ? (repo.desc.length > 99 ? `${repo.desc.slice(0, 99)}...` : repo.desc) : '\u00A0'}
+                    </Card.Text>
 
                     <div className="d-flex">
                         {/* Download Count */}

--- a/client/src/components/RepoPreview.tsx
+++ b/client/src/components/RepoPreview.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
 import { RepoDTO, RepositoryBadge } from '../api/repo.api';
 import { Card, Col, OverlayTrigger, Tooltip } from 'react-bootstrap';
-import { RepositoryService } from '../api/repo.api';
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
 import { BadgeUtils } from '../util/badge';
 
-export const RepoPreview: React.FC<{ repo: RepoDTO, orgNames: Map<number, string> | undefined }> = ( {repo, orgNames} ) => {
+export const RepoPreview: React.FC<{ repo: RepoDTO, orgNames: Map<number, string> | undefined, showCanonical : boolean }> = ( {repo, orgNames, showCanonical} ) => {
+
+    const constructSubtitle = () => {
+        if (repo.organization_id && orgNames && orgNames.has(repo.organization_id)) {
+            {/* If the repository is part of an organization, link to the organization page. */}
+            return <NavLink style={{ textDecoration: 'none'}} to={`/o/${orgNames.get(repo.organization_id)}`}>{orgNames.get(repo.organization_id)}</NavLink>;
+        } else if (repo.badge === RepositoryBadge.official) {
+            {/* If the repository was created by an admin, then it's official*/}
+            return <span>Official repository</span>;
+            {/* If the repository was created by a user, link to user's repositories. */}
+        } else return <NavLink style={{ textDecoration: 'none'}} to={`/u/${repo.canonical_name.split("/")[0]}/repos`}>{repo.canonical_name.split("/")[0]}</NavLink>;
+    }
+
     return (
         <Col key={repo.id} xs={12}>
             <Card>
@@ -14,7 +25,7 @@ export const RepoPreview: React.FC<{ repo: RepoDTO, orgNames: Map<number, string
                     {/* Repository Title with React Router Link */}
                     <Card.Title>
                         <Link to={`/r/${repo.canonical_name}`} className="text-primary">
-                            <span>{repo.name}</span>
+                            {showCanonical ? <span>{repo.canonical_name}</span> : <span>{repo.name}</span>}
                         </Link>
                         {/* Private */}
                         {!repo.public && (
@@ -35,12 +46,17 @@ export const RepoPreview: React.FC<{ repo: RepoDTO, orgNames: Map<number, string
                         }
                     </Card.Title>
 
-                    {/* Organization Name (if exists) */}
-                    {repo.organization_id && (
-                        <Card.Subtitle className="mb-2 text-muted" style={{ fontSize: '0.8rem' }}>
-                            Part of organization {orgNames?.get(repo.organization_id)}
-                        </Card.Subtitle>
+                    {/* Subtitle */}
+                    {showCanonical ? (
+                        <div style={{color: '#0264c5ff', fontWeight: 'bolder', marginBottom: '0.3em' }}>{constructSubtitle()}</div>
+                    ) : (
+                        repo.organization_id && (
+                            <Card.Subtitle className="mb-2 text-muted" style={{ fontSize: '0.8rem' }}>
+                                Part of organization {orgNames?.get(repo.organization_id)}
+                            </Card.Subtitle>
+                        )
                     )}
+
 
                     {/* Last update */}
                     {repo.last_updated && (

--- a/client/src/pages/Explore.css
+++ b/client/src/pages/Explore.css
@@ -1,0 +1,9 @@
+.header-repositories{
+    padding: 20px 27% 0px 27%;
+    border-radius: 10px;
+}
+
+.explore-repositories{
+    padding: 0px 13% 20px 13%;
+    border-radius: 10px;
+}

--- a/client/src/pages/Explore.tsx
+++ b/client/src/pages/Explore.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { Row, Spinner, Button, Pagination, Form } from 'react-bootstrap';
+import { Row, Spinner, Button, Pagination, Form, Col } from 'react-bootstrap';
 import { RepositoryBadge, RepositoryQueryDTO, RepositoryService } from '../api/repo.api';
 import { AxiosError, AxiosResponse } from 'axios';
-import './RepoOfUser.css';
+import './Explore.css';
 import { RepoPreview } from '../components/RepoPreview';
 import { BadgeUtils } from '../util/badge';
 
@@ -21,7 +21,7 @@ export const Explore: React.FC = () => {
     const [showBadgeSponsoredOSS, setShowBadgeSponsoredOSS] = useState(false);
 
     const [pageNumber, setPageNumber] = useState(1);
-    const [pageSize, setPageSize] = useState(10);
+    const [pageSize, setPageSize] = useState(6);
 
     useEffect(() => {
         fetchRepos();
@@ -172,111 +172,117 @@ export const Explore: React.FC = () => {
     }
 
     return (
-        <Row className="g-4 repo-of-user">
+        <Row className="g-4">
             {/* Page Title */}
-            <h1>Explore Repositories</h1>
-            <>
-                <Form onSubmit={(e) => {
-                    e.preventDefault(); // Prevent page reload
-                    handleSearch();     // Trigger search logic
-                }}>
-                    <div className="d-flex justify-content-between">
-                        <div className="d-flex align-items-center flex-grow-1 me-3">
-                            {/* Search Bar */}
-                            <input
-                                type="text"
-                                className="form-control me-2"
-                                placeholder="Search repositories"
-                                value={searchTerm}
-                                onChange={handleSearchChange}
-                            />
-                            <Button variant="primary" className="me-5" type="submit" onClick={handleSearch}>
-                                <i className="bi bi-search"></i>
-                            </Button>
-                            {/* Advanced Search Button */}
-                            <Button className="btn btn-primary" onClick={toggleAdvancedSearch}>
-                                {showAdvancedSearch ? <i className="bi bi-funnel-fill"></i> : <i className="bi bi-funnel"></i>}
-                            </Button>
+            <div className="header-repositories">
+                <h1 className='mb-4'>Explore Repositories</h1>
+                <>
+                    <Form onSubmit={(e) => {
+                        e.preventDefault(); // Prevent page reload
+                        handleSearch();     // Trigger search logic
+                    }}>
+                        <div className="d-flex justify-content-between">
+                            <div className="d-flex align-items-center flex-grow-1 me-3">
+                                {/* Search Bar */}
+                                <input
+                                    type="text"
+                                    className="form-control me-2"
+                                    placeholder="Search repositories"
+                                    value={searchTerm}
+                                    onChange={handleSearchChange}
+                                />
+                                <Button variant="primary" className="me-5" type="submit" onClick={handleSearch}>
+                                    <i className="bi bi-search"></i>
+                                </Button>
+                                {/* Advanced Search Button */}
+                                <Button className="btn btn-primary" onClick={toggleAdvancedSearch}>
+                                    {showAdvancedSearch ? <i className="bi bi-funnel-fill"></i> : <i className="bi bi-funnel"></i>}
+                                </Button>
+                            </div>
                         </div>
-                    </div>
-                </Form>
-    
-                {/* Advanced Search Section */}
-                {showAdvancedSearch && (
-                    <div className="advanced-search">
+                    </Form>
+        
+                    {/* Advanced Search Section */}
+                    {showAdvancedSearch && (
+                        <div className="advanced-search" style={{ marginTop: '20px' }}>
 
-                        {/* Badges - Checkbox for each badge type. */}
-                        {badgeDataBundle.map((badge) => (
-                            <div className="mb-3">
-                                <div className="form-check ms-2 d-flex align-items-center">
-                                    <input
-                                        type="checkbox"
-                                        className="form-check-input form-check-lg"
-                                        checked={badge.checked}
-                                        onChange={badge.onChange}
-                                        id={badge.id}
-                                    />
-                                    <label className="form-check-label fs-5 ms-2" htmlFor={badge.id}>
-                                        <span className={`badge rounded-pill ${BadgeUtils.toBootstrapColor(badge.type)}`}>
-                                            <i className={`bi ${BadgeUtils.toBootstrapIcon(badge.type)}`}> </i>
-                                            {BadgeUtils.toHumanText(badge.type)}
-                                        </span>
-                                    </label>
+                            {/* Badges - Checkbox for each badge type. */}
+                            {badgeDataBundle.map((badge) => (
+                                <div className="mb-3">
+                                    <div className="form-check ms-2 d-flex align-items-center">
+                                        <input
+                                            type="checkbox"
+                                            className="form-check-input form-check-lg"
+                                            checked={badge.checked}
+                                            onChange={badge.onChange}
+                                            id={badge.id}
+                                        />
+                                        <label className="form-check-label fs-5 ms-2" htmlFor={badge.id}>
+                                            <span className={`badge rounded-pill ${BadgeUtils.toBootstrapColor(badge.type)}`}>
+                                                <i className={`bi ${BadgeUtils.toBootstrapIcon(badge.type)}`}> </i>
+                                                {BadgeUtils.toHumanText(badge.type)}
+                                            </span>
+                                        </label>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                        ) 
+                    }
+                </>
+            </div>
+
+            <div className="explore-repositories">
+                {repositories !== null && (
+                    <>
+                        {repositories.hits.length === 0 ? (
+                            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                                Not found any repositories.
+                            </div>
+                        ) : (
+                        <>
+                        {/* Pagination */}
+                            <div className="d-flex flex-wrap gap-3 mt-3 align-items-start">
+                                <div>{renderPagination()}</div>
+
+                                {/* Page size dropdown with inline label */}
+                                <div className="d-flex align-items-center gap-2">
+                                    <label htmlFor="pageSizeSelect" className="mb-0">Results per page:</label>
+                                    <Form.Select
+                                        id="pageSizeSelect"
+                                        value={pageSize}
+                                        onChange={(e) => {
+                                            setPageSize(Number(e.target.value));
+                                            setPageNumber(1);
+                                        }}
+                                        style={{ width: '100px' }}
+                                    >
+                                        {[6, 15, 30, 60, 100].map((size) => (
+                                            <option key={size} value={size}>{size}</option>
+                                        ))}
+                                    </Form.Select>
                                 </div>
                             </div>
-                        ))}
-                    </div>
-                    ) 
-                }
-            </>
 
-            {repositories !== null && (
-                <>
-                    {repositories.hits.length === 0 ? (
-                        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                            Not found any repositories.
-                        </div>
-                    ) : (
-                    <>
-                    {/* Pagination */}
-                        <div className="d-flex flex-wrap gap-3 mt-3 align-items-start">
-                            <div>{renderPagination()}</div>
-
-                            {/* Page size dropdown with inline label */}
-                            <div className="d-flex align-items-center gap-2">
-                                <label htmlFor="pageSizeSelect" className="mb-0">Rows per page:</label>
-                                <Form.Select
-                                    id="pageSizeSelect"
-                                    value={pageSize}
-                                    onChange={(e) => {
-                                        setPageSize(Number(e.target.value));
-                                        setPageNumber(1);
-                                    }}
-                                    style={{ width: '100px' }}
-                                >
-                                    {[5, 10, 25, 50, 100].map((size) => (
-                                        <option key={size} value={size}>{size}</option>
-                                    ))}
-                                </Form.Select>
+                            {/* Repo count */}
+                            <div className='mb-3 mt-2 ms-3' >
+                                Showing <strong>{repositories.hits.length}</strong> of <strong>{repositories.info.total_hits}</strong> results on
+                                page <strong>{repositories.info.page}</strong> of <strong>{repositories.info.total_pages}</strong>
                             </div>
-                        </div>
 
-                        {/* Repo count */}
-                        <div>
-                            Showing <strong>{repositories.hits.length}</strong> of <strong>{repositories.info.total_hits}</strong> results on
-                            page <strong>{repositories.info.page}</strong> of <strong>{repositories.info.total_pages}</strong>
-                        </div>
-
-                        {/* Show repositories */}
-                        <>
-                            {repositories.hits.map((repo) => (
-                                <RepoPreview key={repo.id} repo={repo} orgNames={orgNames} showCanonical={true} />
-                            ))}
+                            {/* Show repositories */}
+                            <Row>
+                                {repositories.hits.map((repo) => (
+                                    <Col key={repo.id} md={4} className="mb-4">
+                                        <RepoPreview repo={repo} orgNames={orgNames} showCanonical={true} />
+                                    </Col>
+                                ))}
+                            </Row>
                         </>
+                        )}
                     </>
-                    )}
-                </>
-            )}
+                )}
+            </div>
         </Row>
     );
 };

--- a/client/src/pages/Explore.tsx
+++ b/client/src/pages/Explore.tsx
@@ -176,25 +176,30 @@ export const Explore: React.FC = () => {
             {/* Page Title */}
             <h1>Explore Repositories</h1>
             <>
-                <div className="d-flex justify-content-between">
-                    <div className="d-flex align-items-center flex-grow-1 me-3">
-                        {/* Search Bar */}
-                        <input
-                            type="text"
-                            className="form-control me-2"
-                            placeholder="Search repositories"
-                            value={searchTerm}
-                            onChange={handleSearchChange}
-                        />
-                         <Button variant="primary" className="me-5" type="submit" onClick={handleSearch}>
-                            <i className="bi bi-search"></i>
-                        </Button>
-                        {/* Advanced Search Button */}
-                        <Button className="btn btn-primary" onClick={toggleAdvancedSearch}>
-                            {showAdvancedSearch ? <i className="bi bi-funnel-fill"></i> : <i className="bi bi-funnel"></i>}
-                        </Button>
+                <Form onSubmit={(e) => {
+                    e.preventDefault(); // Prevent page reload
+                    handleSearch();     // Trigger search logic
+                }}>
+                    <div className="d-flex justify-content-between">
+                        <div className="d-flex align-items-center flex-grow-1 me-3">
+                            {/* Search Bar */}
+                            <input
+                                type="text"
+                                className="form-control me-2"
+                                placeholder="Search repositories"
+                                value={searchTerm}
+                                onChange={handleSearchChange}
+                            />
+                            <Button variant="primary" className="me-5" type="submit" onClick={handleSearch}>
+                                <i className="bi bi-search"></i>
+                            </Button>
+                            {/* Advanced Search Button */}
+                            <Button className="btn btn-primary" onClick={toggleAdvancedSearch}>
+                                {showAdvancedSearch ? <i className="bi bi-funnel-fill"></i> : <i className="bi bi-funnel"></i>}
+                            </Button>
+                        </div>
                     </div>
-                </div>
+                </Form>
     
                 {/* Advanced Search Section */}
                 {showAdvancedSearch && (

--- a/client/src/pages/Explore.tsx
+++ b/client/src/pages/Explore.tsx
@@ -265,7 +265,7 @@ export const Explore: React.FC = () => {
                         {/* Show repositories */}
                         <>
                             {repositories.hits.map((repo) => (
-                                <RepoPreview key={repo.id} repo={repo} orgNames={orgNames} />
+                                <RepoPreview key={repo.id} repo={repo} orgNames={orgNames} showCanonical={true} />
                             ))}
                         </>
                     </>

--- a/client/src/pages/Explore.tsx
+++ b/client/src/pages/Explore.tsx
@@ -1,0 +1,277 @@
+import React, { useEffect, useState } from 'react';
+import { Row, Spinner, Button, Pagination, Form } from 'react-bootstrap';
+import { RepositoryBadge, RepositoryQueryDTO, RepositoryService } from '../api/repo.api';
+import { AxiosError, AxiosResponse } from 'axios';
+import './RepoOfUser.css';
+import { RepoPreview } from '../components/RepoPreview';
+import { BadgeUtils } from '../util/badge';
+
+export const Explore: React.FC = () => {
+    const [orgNames, setOrgNames] = useState<Map<number, string>>();
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const [repositories, setRepositories] = useState<RepositoryQueryDTO | null>(null);
+
+    const [searchTerm, setSearchTerm] = useState('');
+    const [showAdvancedSearch, setShowAdvancedSearch] = useState(false);
+
+    const [showBadgeOfficial, setShowBadgeOfficial] = useState(false);
+    const [showBadgeVerified, setShowBadgeVerified] = useState(false);
+    const [showBadgeSponsoredOSS, setShowBadgeSponsoredOSS] = useState(false);
+
+    const [pageNumber, setPageNumber] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+
+    useEffect(() => {
+        fetchRepos();
+    }, [pageNumber, pageSize, showBadgeOfficial, showBadgeVerified, showBadgeSponsoredOSS]);
+
+    const handleSearch = async () => {
+        setPageNumber(1); 
+        fetchRepos();
+    }
+
+    const fetchRepos = () => {
+        if (repositories === null || repositories.hits.length == 0) {
+            setLoading(true);
+        }
+
+        setError('');
+
+        RepositoryService.GetPublicRepositories(searchTerm, pageNumber, pageSize, showBadgeOfficial, showBadgeSponsoredOSS, showBadgeVerified).then((res: AxiosResponse<RepositoryQueryDTO>) => {
+            setRepositories(res.data);
+            if (res.data.info.page > res.data.info.total_pages) {
+                handlePageChange(res.data.info.total_pages);
+            }
+            const orgNamesMap = new Map(Object.entries(res.data.organization_names).map(([key, value]) => [Number(key), value]));
+            setOrgNames(orgNamesMap);
+        }).catch((err: AxiosError) => {
+            setError((err.response?.data as any)["detail"]["message"]);
+            setRepositories(null);
+        }).finally(() => {
+            setLoading(false);
+        });
+    }
+
+    const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setSearchTerm(e.target.value);
+    };
+
+    const handlePageChange = (page: number) => {
+        setPageNumber(page);
+    };
+
+    const toggleAdvancedSearch = () => {
+        setShowAdvancedSearch(!showAdvancedSearch);
+    };
+
+    const handleBadgeOfficialChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setShowBadgeOfficial(e.target.checked);
+    };
+
+    const handleBadgeVerifiedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setShowBadgeVerified(e.target.checked);
+    };
+
+    const handleBadgeSponsoredOSSChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setShowBadgeSponsoredOSS(e.target.checked);
+    };
+
+    const renderPagination = () => {
+        if (!repositories || repositories.info.total_pages <= 1) return null;
+
+        const items = [];
+        const maxPagesToShow = 10;
+        const startPage = Math.max(1, repositories.info.page - Math.floor(maxPagesToShow / 2));
+        const endPage = Math.min(repositories.info.total_pages, startPage + maxPagesToShow - 1);
+
+        items.push(
+            <Pagination.First
+                key="first"
+                onClick={() => handlePageChange(1)}
+                style={{ width: '48px', textAlign: 'center' }}
+            />
+        );
+
+        items.push(
+            <Pagination.Prev
+                key="prev"
+                disabled={repositories.info.page <= 1}
+                onClick={() => handlePageChange(repositories.info.page - 1)}
+                style={{ width: '48px', textAlign: 'center' }}
+            />
+        );
+
+
+        for (let page = startPage; page <= endPage; page++) {
+            items.push(
+                <Pagination.Item
+                    key={page}
+                    active={page === repositories.info.page}
+                    onClick={() => handlePageChange(page)}
+                    style={{ width: '48px', textAlign: 'center' }}
+                >
+                    {page}
+                </Pagination.Item>
+            );
+        }
+
+        items.push(
+            <Pagination.Next
+                key="next"
+                disabled={repositories.info.page >= repositories.info.total_pages}
+                onClick={() => handlePageChange(repositories.info.page + 1)}
+                style={{ width: '48px', textAlign: 'center' }}
+            />
+        );
+
+        items.push(
+            <Pagination.Last
+                key="last"
+                onClick={() => handlePageChange(repositories.info.total_pages)}
+                style={{ width: '48px', textAlign: 'center' }}
+            />
+        );
+
+        return <Pagination>{items}</Pagination>;
+    };
+
+    const badgeDataBundle = [
+        {
+            type: RepositoryBadge.official,
+            checked: showBadgeOfficial,
+            onChange: handleBadgeOfficialChange,
+            id: "officialCheckbox",
+        },
+        {
+            type: RepositoryBadge.verified,
+            checked: showBadgeVerified,
+            onChange: handleBadgeVerifiedChange,
+            id: "verifiedCheckbox",
+        },
+        {
+            type: RepositoryBadge.sponsored_oss,
+            checked: showBadgeSponsoredOSS,
+            onChange: handleBadgeSponsoredOSSChange,
+            id: "sponsoredOSSCeckbox",
+        },
+    ];
+
+
+    if (loading) {
+        return (
+            <div className="d-flex justify-content-center align-items-center">
+                <Spinner animation="border" />
+            </div>
+        );
+    }
+
+    if (error) {
+        return <div className="alert alert-danger">{error}</div>;
+    }
+
+    return (
+        <Row className="g-4 repo-of-user">
+            {/* Page Title */}
+            <h1>Explore Repositories</h1>
+            <>
+                <div className="d-flex justify-content-between">
+                    <div className="d-flex align-items-center flex-grow-1 me-3">
+                        {/* Search Bar */}
+                        <input
+                            type="text"
+                            className="form-control me-2"
+                            placeholder="Search repositories"
+                            value={searchTerm}
+                            onChange={handleSearchChange}
+                        />
+                         <Button variant="primary" className="me-5" type="submit" onClick={handleSearch}>
+                            <i className="bi bi-search"></i>
+                        </Button>
+                        {/* Advanced Search Button */}
+                        <Button className="btn btn-primary" onClick={toggleAdvancedSearch}>
+                            {showAdvancedSearch ? <i className="bi bi-funnel-fill"></i> : <i className="bi bi-funnel"></i>}
+                        </Button>
+                    </div>
+                </div>
+    
+                {/* Advanced Search Section */}
+                {showAdvancedSearch && (
+                    <div className="advanced-search">
+
+                        {/* Badges - Checkbox for each badge type. */}
+                        {badgeDataBundle.map((badge) => (
+                            <div className="mb-3">
+                                <div className="form-check ms-2 d-flex align-items-center">
+                                    <input
+                                        type="checkbox"
+                                        className="form-check-input form-check-lg"
+                                        checked={badge.checked}
+                                        onChange={badge.onChange}
+                                        id={badge.id}
+                                    />
+                                    <label className="form-check-label fs-5 ms-2" htmlFor={badge.id}>
+                                        <span className={`badge rounded-pill ${BadgeUtils.toBootstrapColor(badge.type)}`}>
+                                            <i className={`bi ${BadgeUtils.toBootstrapIcon(badge.type)}`}> </i>
+                                            {BadgeUtils.toHumanText(badge.type)}
+                                        </span>
+                                    </label>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                    ) 
+                }
+            </>
+
+            {repositories !== null && (
+                <>
+                    {repositories.hits.length === 0 ? (
+                        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                            Not found any repositories.
+                        </div>
+                    ) : (
+                    <>
+                    {/* Pagination */}
+                        <div className="d-flex flex-wrap gap-3 mt-3 align-items-start">
+                            <div>{renderPagination()}</div>
+
+                            {/* Page size dropdown with inline label */}
+                            <div className="d-flex align-items-center gap-2">
+                                <label htmlFor="pageSizeSelect" className="mb-0">Rows per page:</label>
+                                <Form.Select
+                                    id="pageSizeSelect"
+                                    value={pageSize}
+                                    onChange={(e) => {
+                                        setPageSize(Number(e.target.value));
+                                        setPageNumber(1);
+                                    }}
+                                    style={{ width: '100px' }}
+                                >
+                                    {[5, 10, 25, 50, 100].map((size) => (
+                                        <option key={size} value={size}>{size}</option>
+                                    ))}
+                                </Form.Select>
+                            </div>
+                        </div>
+
+                        {/* Repo count */}
+                        <div>
+                            Showing <strong>{repositories.hits.length}</strong> of <strong>{repositories.info.total_hits}</strong> results on
+                            page <strong>{repositories.info.page}</strong> of <strong>{repositories.info.total_pages}</strong>
+                        </div>
+
+                        {/* Show repositories */}
+                        <>
+                            {repositories.hits.map((repo) => (
+                                <RepoPreview key={repo.id} repo={repo} orgNames={orgNames} />
+                            ))}
+                        </>
+                    </>
+                    )}
+                </>
+            )}
+        </Row>
+    );
+};

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -22,12 +22,12 @@ export const RepositoriesOfUser: React.FC = () => {
     const [searchTerm, setSearchTerm] = useState('');
     const [showAdvancedSearch, setShowAdvancedSearch] = useState(false);
     const [selectedOrg, setSelectedOrg] = useState<number | undefined>(undefined);
-    const [showPublic, setShowPublic] = useState(true);
-    const [showPrivate, setShowPrivate] = useState(true);
+    const [showPublic, setShowPublic] = useState(false);
+    const [showPrivate, setShowPrivate] = useState(false);
 
-    const [showBadgeOfficial, setShowBadgeOfficial] = useState(true);
-    const [showBadgeVerified, setShowBadgeVerified] = useState(true);
-    const [showBadgeSponsoredOSS, setShowBadgeSponsoredOSS] = useState(true);
+    const [showBadgeOfficial, setShowBadgeOfficial] = useState(false);
+    const [showBadgeVerified, setShowBadgeVerified] = useState(false);
+    const [showBadgeSponsoredOSS, setShowBadgeSponsoredOSS] = useState(false);
 
     let navigate = useNavigate();
 
@@ -100,21 +100,30 @@ export const RepositoriesOfUser: React.FC = () => {
     };
 
     const filterRepos = (searchTerm: string, orgId?: number, showPublic?: boolean, showPrivate?: boolean, showBadgeOfficial?: boolean, showBadgeVerified?: boolean, showBadgeSponsoredOSS?: boolean) => {
-        let filtered = repositories.filter((repo) => {
-            const matchesSearch =
-                repo.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                (repo.desc && repo.desc.toLowerCase().includes(searchTerm.toLowerCase()));
-            const matchesOrg = orgId ? repo.organization_id === orgId : true;
-            const matchesVisibility = (showPublic && repo.public) || (showPrivate && !repo.public);
-            const matchesBadge =
-                (repo.badge == RepositoryBadge.none)
-                || (repo.badge == RepositoryBadge.official && showBadgeOfficial)
-                || (repo.badge == RepositoryBadge.verified && showBadgeVerified)
-                || (repo.badge == RepositoryBadge.sponsored_oss && showBadgeSponsoredOSS);
-            return matchesSearch && matchesOrg && matchesVisibility && matchesBadge;
-        });
-        setFilteredRepos(filtered);
-    };
+    const noBadgeFiltersSelected = !showBadgeOfficial && !showBadgeVerified && !showBadgeSponsoredOSS;
+    const noVisibilityFiltersSelected = !showPublic && !showPrivate;
+
+    const filtered = repositories.filter((repo) => {
+        const matchesSearch =
+            repo.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            (repo.desc && repo.desc.toLowerCase().includes(searchTerm.toLowerCase()));
+        const matchesOrg = orgId ? repo.organization_id === orgId : true;
+        const matchesVisibility = noVisibilityFiltersSelected
+            || (showPublic && repo.public)
+            || (showPrivate && !repo.public);
+        const matchesBadge = noBadgeFiltersSelected
+            || (repo.badge === RepositoryBadge.official && showBadgeOfficial)
+            || (repo.badge === RepositoryBadge.verified && showBadgeVerified)
+            || (repo.badge === RepositoryBadge.sponsored_oss && showBadgeSponsoredOSS);
+
+        return (matchesSearch && matchesOrg && matchesVisibility && matchesBadge && (noBadgeFiltersSelected || repo.badge !== RepositoryBadge.none)
+        );
+    });
+
+    setFilteredRepos(filtered);
+};
+
+
 
     // Respecting DRY.
     // TODO: `checked` stores reactive state, but `badgeDataBundle` is a regular array,

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -116,8 +116,7 @@ export const RepositoriesOfUser: React.FC = () => {
             || (repo.badge === RepositoryBadge.verified && showBadgeVerified)
             || (repo.badge === RepositoryBadge.sponsored_oss && showBadgeSponsoredOSS);
 
-        return (matchesSearch && matchesOrg && matchesVisibility && matchesBadge && (noBadgeFiltersSelected || repo.badge !== RepositoryBadge.none)
-        );
+        return (matchesSearch && matchesOrg && matchesVisibility && matchesBadge);
     });
 
     setFilteredRepos(filtered);

--- a/client/src/pages/RepoOfUser.tsx
+++ b/client/src/pages/RepoOfUser.tsx
@@ -269,7 +269,7 @@ export const RepositoriesOfUser: React.FC = () => {
 
                 {
                     filteredRepos.map((repo) => (
-                        <RepoPreview key={repo.id} repo={repo} orgNames={orgNames} />
+                        <RepoPreview key={repo.id} repo={repo} orgNames={orgNames} showCanonical={false} />
                     ))
                 }
                 </>

--- a/client/src/pages/RepoStarred.tsx
+++ b/client/src/pages/RepoStarred.tsx
@@ -61,7 +61,7 @@ export const RepoStarred: React.FC = () => {
 
             { fullResult!.repos.length >= 1 ? (
                 fullResult!.repos.map((repo) => (
-                    <RepoPreview key={repo.id} repo={repo} orgNames={orgNames} />
+                    <RepoPreview key={repo.id} repo={repo} orgNames={orgNames} showCanonical={true} />
                 ))
             ) : ( <div>No repositories starred yet.</div> ) }
         </Row >

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -152,8 +152,7 @@ def get_starred_repositories_of_user(
     return ReposOfUserDTO(user_id=user.id, user_name=user.username, repos=repos, organization_names=org_names)
 
 @router.get("/public/", response_model=RepositoriesResultDTO, status_code=200, summary="Search all public repositories with paginated results")
-@pre_authorize([UserRole.user, UserRole.admin, UserRole.superadmin])
-async def search_public_repositories(jwt: JWTDep,  page_number: int, page_size: int, show_badge_official: bool, show_badge_sponsored: bool,
+async def search_public_repositories(page_number: int, page_size: int, show_badge_official: bool, show_badge_sponsored: bool,
                                      show_badge_verified: bool, query: str = "", repo_service: RepositoryService = Depends(get_repo_service),
                                      org_service: OrganizationService = Depends(get_org_service)):
     repos, result_info = repo_service.search_public_repositories(query, page_number, page_size, show_badge_official, show_badge_sponsored, show_badge_verified)

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from typing import List
 from fastapi import APIRouter, Depends
-from app.api.repo.repo_dto import ReposOfUserDTO, RepositoryCreateDTO, RepositoryDTO, RepositoryExtDTO, RepositoryDescUpdateDTO, RepositoryVisibilityUpdateDTO, ToggleStarRepoDTO
+from app.api.repo.repo_dto import ReposOfUserDTO, RepositoryCreateDTO, RepositoryDTO, RepositoryExtDTO, \
+    RepositoryDescUpdateDTO, RepositoryVisibilityUpdateDTO, ToggleStarRepoDTO, RepositoriesResultDTO
 from app.api.repo.repo_service import RepositoryService, get_repo_service
 from app.api.config.auth import get_id_from_jwt, get_id_from_jwt_optional, pre_authorize
 from app.api.user.user_model import User, UserRole
@@ -149,3 +150,13 @@ def get_starred_repositories_of_user(
     org_names = org_service.get_org_names_from_repos(repos)
 
     return ReposOfUserDTO(user_id=user.id, user_name=user.username, repos=repos, organization_names=org_names)
+
+@router.get("/public/", response_model=RepositoriesResultDTO, status_code=200, summary="Search all public repositories with paginated results")
+@pre_authorize([UserRole.user, UserRole.admin, UserRole.superadmin])
+async def search_public_repositories(jwt: JWTDep,  page_number: int, page_size: int, show_badge_official: bool, show_badge_sponsored: bool,
+                                     show_badge_verified: bool, query: str = "", repo_service: RepositoryService = Depends(get_repo_service),
+                                     org_service: OrganizationService = Depends(get_org_service)):
+    repos, result_info = repo_service.search_public_repositories(query, page_number, page_size, show_badge_official, show_badge_sponsored, show_badge_verified)
+    org_names = org_service.get_org_names_from_repos(repos)
+    repos = [_repo_model_to_dto(repo) for repo in repos]
+    return RepositoriesResultDTO(hits=repos, info=result_info, organization_names=org_names)

--- a/server/app/api/repo/repo_dto.py
+++ b/server/app/api/repo/repo_dto.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Dict, List
 from pydantic import BaseModel, EmailStr, Field
+
+from app.api.config.pagination import PaginatedResultInfoDTO
 from app.api.user.user_model import UserRole
 from app.api.repo.repo_model import RepositoryBadge
 
@@ -44,3 +46,8 @@ class RepositoryDescUpdateDTO(BaseModel):
 
 class RepositoryVisibilityUpdateDTO(BaseModel):
     public: bool
+
+class RepositoriesResultDTO(BaseModel):
+    hits: List[RepositoryDTO]
+    info: PaginatedResultInfoDTO
+    organization_names: Dict[int, str]

--- a/server/app/api/repo/repo_repo.py
+++ b/server/app/api/repo/repo_repo.py
@@ -1,8 +1,9 @@
 from typing import List
 from sqlmodel import Session, or_, select
-from app.api.repo.repo_model import Repository, RepositoryStar
+from app.api.repo.repo_model import Repository, RepositoryStar, RepositoryBadge
 from app.api.user.user_model import User
 from app.api.org.org_model import Organization, OrganizationMembers
+from sqlalchemy import func
 
 class RepositoryRepo:
     def __init__(self, session: Session):
@@ -93,3 +94,34 @@ class RepositoryRepo:
     def remove(self, repo: Repository) -> None:
         self.session.delete(repo)
         self.session.commit()
+
+    def search_public_repositories(self, query, page_number, page_size, show_badge_official, show_badge_sponsored,
+                                   show_badge_verified) -> tuple[list[Repository], int]:
+        filters = [Repository.public == True]
+
+        if query is not None and query.strip():
+            filters.append(Repository.name.ilike(f"{query}%"))
+
+        badge_filters = []
+        if show_badge_official:
+            badge_filters.append(Repository.badge == RepositoryBadge.official)
+        if show_badge_sponsored:
+            badge_filters.append(Repository.badge == RepositoryBadge.sponsored_oss)
+        if show_badge_verified:
+            badge_filters.append(Repository.badge == RepositoryBadge.verified)
+
+        if badge_filters:
+            filters.append(or_(*badge_filters))
+
+        count_query = select(func.count()).where(*filters)
+        total_hits = self.session.exec(count_query).one()
+
+        query_stmt = (
+            select(Repository)
+            .where(*filters)
+            .order_by(Repository.stars.desc())
+            .offset((page_number - 1) * page_size)
+            .limit(page_size)
+        )
+        results = self.session.exec(query_stmt).all()
+        return results, total_hits

--- a/server/app/api/repo/repo_service.py
+++ b/server/app/api/repo/repo_service.py
@@ -1,15 +1,18 @@
+import math
 from typing import List, Tuple
 from fastapi import Depends
 from app.api.config.exception_handler import AccessDeniedException, ConflictException, FieldTakenException, NotFoundException, InvalidInputException
 from sqlmodel import Session
 from app.api.config.database import get_database
+from app.api.config.pagination import PaginatedResultInfoDTO
 from app.api.events.event_model import EventLevel
 from app.api.events.event_service import EventService
 from app.api.user.user_model import User, UserRole, UserBadge
 from app.api.user.user_repo import UserRepo
 from app.api.repo.repo_repo import RepositoryRepo
 from app.api.repo.repo_model import Repository, RepositoryBadge, RepositoryStar
-from app.api.repo.repo_dto import RepositoryCreateDTO, RepositoryDescUpdateDTO, RepositoryVisibilityUpdateDTO
+from app.api.repo.repo_dto import RepositoryCreateDTO, RepositoryDescUpdateDTO, RepositoryVisibilityUpdateDTO, \
+    RepositoriesResultDTO
 from app.api.org.org_repo import OrganizationRepo
 from app.api.team.team_repo import TeamRepo
 from app.api.access_control.access_control_service import AccessControlService
@@ -162,6 +165,25 @@ class RepositoryService:
     
     def remove_repo(self, repo: Repository) -> None:
         self.repo_repo.remove(repo)
-    
+
+    def search_public_repositories(self, query, page_number, page_size, show_badge_official, show_badge_sponsored,
+                                   show_badge_verified) -> tuple[list[Repository], PaginatedResultInfoDTO]:
+        if page_number < 1:
+            page_number = 1
+        if page_size < 1:
+            page_size = 1
+
+        repositories, total_hits = self.repo_repo.search_public_repositories(query, page_number, page_size,
+                                                    show_badge_official, show_badge_sponsored, show_badge_verified)
+        total_pages = math.ceil(total_hits / page_size)
+        result_info = PaginatedResultInfoDTO(
+            page=page_number,
+            page_size=page_size,
+            total_pages=total_pages,
+            total_hits=total_hits
+        )
+        return repositories, result_info
+
+
 def get_repo_service(session: Session = Depends(get_database)) -> RepositoryService:
     return RepositoryService(session)

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -1342,3 +1342,117 @@ def test_search_public_repositories_min_page_and_size(repo_service):
     assert info.total_hits == 1
     repo_service.repo_repo.search_public_repositories.assert_called_once_with(
         "r", 1, 1, False, False, False)
+
+def test_search_public_respositories_integration():
+    with TestClient(app) as client:
+        def create_user(username: str, email: str, password: str = "Password123") -> dict:
+            data = {"username": username, "email": email, "password": password}
+            response = client.post("/api/v1/users", json=data)
+            assert response.status_code == 200
+            return response.json()
+        def login(data: dict) -> dict:
+            response = client.post("/api/v1/users/login", json=data)
+            assert response.status_code == 200
+            jwt = response.json()["token"]
+            return {"Authorization": f"Bearer {jwt}"}
+        def add_repo(user, name: str, public: bool) -> dict:
+            header = login({"username": user["username"], "password": "Password123"})
+            data = {
+                "name": name,
+                "desc": "",
+                "public": public,
+                "organization_id": None,
+            }
+            response = client.post("/api/v1/repositories/", json=data, headers=header)
+            return response.json()
+
+        # Login as superadmin using password from file
+        superadmin_creds = {
+            "username": "admin",
+            "password": ""
+        }
+        with open("./volume-server-cfg/superadmin_password.txt", "r") as f:
+            superadmin_creds["password"] = old_password = f.readline()
+
+        superadmin_header = login(superadmin_creds)
+
+        # Change superadmin password
+        change_pw_payload = {
+            "old_password": old_password,
+            "new_password": "Password1"
+        }
+        response = client.post("/api/v1/users/password", json=change_pw_payload, headers=superadmin_header)
+        assert response.status_code == 204
+
+        superadmin_creds["password"] = "Password1"
+        superadmin_header = login(superadmin_creds)
+
+        # Register an admin
+        new_admin_data = {
+            "username": "TestAdmin",
+            "email": "admin@example.com",
+            "password": "AdminPass123"
+        }
+        response = client.post("/api/v1/users/register-admin", json=new_admin_data, headers=superadmin_header)
+        assert response.status_code == 200
+
+        # Register regular users (to later update badge)
+        user1 = create_user("user1", "user1@mail.com")
+        user2 = create_user("user2", "user2@mail.com")
+
+        # login as admin
+        admin_auth = login({"username": new_admin_data["username"], "password": new_admin_data["password"]})
+
+        # Update user badge
+        badge_update_dto = {
+            "user_id": user2["id"],
+            "badge": "verified"
+        }
+        response = client.put("/api/v1/users/badge", json=badge_update_dto, headers=admin_auth)
+        assert response.status_code == 200
+        updated_user = response.json()
+        assert updated_user["badge"] == "verified"
+        # Add repositories for users
+        add_repo(user1, "Repo1", True)
+        add_repo(user1, "Repo2", False)
+        add_repo(user2, "Repo3", True)
+        add_repo(user2, "Repo4", False)
+        # Search repositories with filtered badges (this won't get repositories which badge is none)
+        params = {
+            "query": "re",
+            "page_number": 1,
+            "page_size": 10,
+            "show_badge_official": True,
+            "show_badge_verified": True,
+            "show_badge_sponsored": True,
+        }
+        response = client.get("/api/v1/repositories/public/", headers=admin_auth, params=params)
+        assert response.status_code == 200
+        paginated = response.json()
+        assert len(paginated["hits"]) == 1
+        repo = paginated["hits"][0]
+        assert repo["owner_id"] == user2["id"]
+        assert repo["badge"] == "verified"
+
+        # Search repositories without filtering badges
+        params = {
+            "query": "re",
+            "page_number": 1,
+            "page_size": 10,
+            "show_badge_official": False,
+            "show_badge_verified": False,
+            "show_badge_sponsored": False,
+        }
+        response = client.get("/api/v1/repositories/public/", headers=admin_auth, params=params)
+        assert response.status_code == 200
+        paginated = response.json()
+        for repo in paginated["hits"]:
+            if repo["owner_id"] == user2["id"]:
+                assert repo["badge"] == "verified"
+            else:
+                assert repo["badge"] == 'none'
+            assert repo["public"] is True
+        assert len(paginated["hits"]) == 2
+
+
+

--- a/server/app/tests/test_repository.py
+++ b/server/app/tests/test_repository.py
@@ -6,6 +6,7 @@ from typing import Callable
 
 from sqlmodel import SQLModel, Session
 
+from app.api.config.pagination import PaginatedResultDTO, PaginatedResultInfoDTO
 from app.api.config.security import hash_password
 from app.api.user.user_model import User, UserRole
 from app.api.user.user_repo import UserRepo
@@ -1294,4 +1295,50 @@ class TestUpdateRepoAttrs():
             mock.call(repo, "public", False),
         ]
         assert repo_service.repo_repo.set_attribute.call_args_list == expected_calls
-    
+
+
+def test_search_public_repositories_success(repo_service):
+    query = "re"
+    page_number = 1
+    page_size = 2
+
+    repo1 = mock.MagicMock(spec=Repository)
+    repo1.id = 1
+    repo1.name = "repo"
+    repo1.public = True
+    repo1.badge = None
+    repo2 = mock.MagicMock(spec=Repository)
+    repo2.id = 2
+    repo2.name = "repo2"
+    repo2.public = True
+    repo2.badge = RepositoryBadge.verified
+    repo_list = [repo1, repo2]
+    total_hits = 5
+
+    repo_service.repo_repo.search_public_repositories.return_value = (repo_list, total_hits)
+    repos, info = repo_service.search_public_repositories(query, page_number, page_size, False, False, False)
+
+    assert isinstance(info, PaginatedResultInfoDTO)
+    assert info.page == page_number
+    assert info.page_size == page_size
+    assert info.total_hits == total_hits
+    assert info.total_pages == 3  # ceil(5 / 2)
+    repo_service.repo_repo.search_public_repositories.assert_called_once_with(
+        query, page_number, page_size, False, False, False)
+
+def test_search_public_repositories_min_page_and_size(repo_service):
+    repo1 = mock.MagicMock(spec=Repository)
+    repo1.id = 1
+    repo1.name = "repo"
+    repo1.public = True
+    repo1.badge = None
+    repo_service.repo_repo.search_public_repositories.return_value = ([repo1], 1)
+
+    repos, info = repo_service.search_public_repositories("r", 0, 0, False, False, False)
+
+    assert info.page == 1
+    assert info.page_size == 1
+    assert info.total_pages == 1
+    assert info.total_hits == 1
+    repo_service.repo_repo.search_public_repositories.assert_called_once_with(
+        "r", 1, 1, False, False, False)


### PR DESCRIPTION
Closes #50 

Implemented `Explore` section.

I’ve updated the filtering behavior on both `Explore` page and `Repositories` page. Previously, the way badge filters worked on the Repositories page was a bit confusing and unintuitive to me.
Now, badges are unchecked by default. When no badges are selected, it returns all repositories. Checking one or more badges filters the results to only show repositories with those selected badges.
An alternative approach could be what previously was (to have all badge filters checked by default), but that would require adding a “None” badge option as well (so users could explicitly include/exclude repositories that don't have a badge).
I think the current approach is more intuitive. Please feel free to share what you think.