### PR TITLE
Feature api caching

### DIFF
--- a/server/app/api/events/event_controller.py
+++ b/server/app/api/events/event_controller.py
@@ -5,10 +5,15 @@ from app.api.config.pagination import PaginatedResultDTO
 from app.api.events.event_service import EventService, get_event_service
 from app.api.events.event_model import EventLevel
 from app.api.config.exception_handler import InvalidInputException
+from app.api.user.user_model import UserRole
+from app.api.config.cache import cache
+from app.api.config.auth import JWTDep, pre_authorize
 
 router = APIRouter(prefix="/events", tags=["events"])
 
 @router.get("/", response_model=PaginatedResultDTO, status_code=200, summary="Query for analytics")
-async def query_analytics(query: str, page_number: int, page_size: int, sort_by: str, sort_ascending: bool, event_service: EventService = Depends(get_event_service)):
+@cache(expire=10)
+@pre_authorize([UserRole.admin, UserRole.superadmin])
+async def query_analytics(jwt: JWTDep, query: str, page_number: int, page_size: int, sort_by: str, sort_ascending: bool, event_service: EventService = Depends(get_event_service)):
     result = event_service.query(query, page_number, page_size, sort_by, sort_ascending)
     return result

--- a/server/app/api/org/org_controller.py
+++ b/server/app/api/org/org_controller.py
@@ -8,6 +8,7 @@ from app.api.config.auth import JWTDep, JWTDepOptional
 from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDTO, OrganizationDTOBasic, OrganizationDescUpdateDTO, OrganizationHasMemberDTO
 from app.api.org.org_service import OrganizationService, get_org_service
 from app.api.access_control.access_control_service import AccessControlService
+from app.api.config.cache import cache
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
 
@@ -24,6 +25,7 @@ def get_by_name(org_name: str, org_service: OrganizationService = Depends(get_or
     return org
 
 @router.get("/my", response_model=List[OrganizationDTOBasic], status_code=200, summary="Find all organizations that I am a member of")
+@cache(expire=10)
 @pre_authorize([UserRole.user, UserRole.admin])
 def find_my_orgs(jwt: JWTDep, org_service: OrganizationService = Depends(get_org_service)):
     user_id = get_id_from_jwt(jwt)

--- a/server/app/api/repo/repo_controller.py
+++ b/server/app/api/repo/repo_controller.py
@@ -14,6 +14,7 @@ from app.api.repo.repo_model import Repository
 from app.api.access_control.access_control_service import AccessControlService, get_access_control_service
 from app.api.events.event_service import EventService, get_event_service
 from app.api.events.event_model import EventLevel
+from app.api.config.cache import cache
 
 router = APIRouter(prefix="/repositories", tags=["repositories"])
 
@@ -28,6 +29,7 @@ def register_repo(jwt: JWTDep, dto: RepositoryCreateDTO, repo_service: Repositor
     return repo
 
 @router.get("/u/{username}", response_model=ReposOfUserDTO, status_code=200, summary="Get repositories of user")
+@cache(expire=10)
 def get_repositories_of_user(
     jwt: JWTDepOptional, 
     username: str, 
@@ -52,6 +54,7 @@ def get_repositories_of_user(
     return ReposOfUserDTO(user_id=user_id, user_name=user.username, repos=repos, organization_names=org_names)
 
 @router.get("/name/{repo_canonical_name:path}", response_model=RepositoryExtDTO, status_code=200, summary="Find repository by its full name")
+@cache(expire=60)
 def get_repo_by_canonical_name(
     jwt: JWTDepOptional, 
     repo_canonical_name: str, 
@@ -133,6 +136,7 @@ def toggle_repo_star(
     return ToggleStarRepoDTO(**repo.model_dump(), starred=starred)
 
 @router.get("/starred/u/{username}", response_model=ReposOfUserDTO, status_code=200, summary="Get starred repositories of user")
+@cache(expire=10)
 def get_starred_repositories_of_user(
     username: str, 
     user_service: UserService = Depends(get_user_service),
@@ -152,6 +156,7 @@ def get_starred_repositories_of_user(
     return ReposOfUserDTO(user_id=user.id, user_name=user.username, repos=repos, organization_names=org_names)
 
 @router.get("/public/", response_model=RepositoriesResultDTO, status_code=200, summary="Search all public repositories with paginated results")
+@cache(expire=10)
 async def search_public_repositories(page_number: int, page_size: int, show_badge_official: bool, show_badge_sponsored: bool,
                                      show_badge_verified: bool, query: str = "", repo_service: RepositoryService = Depends(get_repo_service),
                                      org_service: OrganizationService = Depends(get_org_service)):

--- a/server/app/api/tags/tag_controller.py
+++ b/server/app/api/tags/tag_controller.py
@@ -4,16 +4,19 @@ from fastapi import APIRouter, Depends
 from app.api.tags.tag_dto import TagDTO
 from app.api.tags.tag_service import TagService, get_tag_service
 from app.api.config.pagination import PaginatedDTO, PaginationParams
+from app.api.config.cache import cache
 
 router = APIRouter(prefix="/tags", tags=["tags"])
 
 @router.get("/", response_model=List[TagDTO], status_code=200, summary="Get all tags of a repository")
+@cache(expire=10)
 def get_tags_of_repo(repo_name: str, tag_service: TagService = Depends(get_tag_service)):
     tags = tag_service.get_tags_by_repository_name(repo_name)
     tags = [TagDTO.from_tag(tag) for tag in tags]
     return tags
 
 @router.get("/filter", response_model=PaginatedDTO[TagDTO], status_code=200, summary="Filters tags of a repository")
+@cache(expire=10)
 def filter(
         repo_name: str,
         search_query: str = "",

--- a/server/app/api/team/team_controller.py
+++ b/server/app/api/team/team_controller.py
@@ -6,6 +6,7 @@ from app.api.user.user_model import UserRole
 from app.api.config.auth import JWTDep
 from app.api.team.team_dto import TeamAddMemberDTO, TeamCreateDTO, TeamDTOBasic
 from app.api.team.team_service import TeamService, get_team_service
+from app.api.config.cache import cache
 
 router = APIRouter(prefix="/teams", tags=["teams"])
 
@@ -17,6 +18,7 @@ def create_team(jwt: JWTDep, dto: TeamCreateDTO, team_service: TeamService = Dep
     return team
 
 @router.get("/o/{org_id}", response_model=List[TeamDTOBasic], status_code=200, summary="Find all teams by organization")
+@cache(expire=5)
 @pre_authorize([UserRole.user, UserRole.admin])
 def find_by_org_id(jwt: JWTDep, org_id: int, team_service: TeamService = Depends(get_team_service)):
     user_id = get_id_from_jwt(jwt)

--- a/server/app/api/user/user_controller.py
+++ b/server/app/api/user/user_controller.py
@@ -6,9 +6,9 @@ from app.api.user.user_dto import UserDTO, UserPasswordChangeDTO, UserRegisterDT
      UserBadgeDTO
 from app.api.user.user_service import UserService, get_user_service
 from app.api.user.user_model import UserRole, User, UserBadge
-from fastapi_cache.decorator import cache
 from app.api.config.auth import JWTBearer, JWTDep, get_id_from_jwt
 from app.api.config.auth import pre_authorize
+from app.api.config.cache import cache
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -44,12 +44,14 @@ def test(jwt: JWTDep):
     ]
 
 @router.get("/search/{query}", status_code=200, response_model=List[UserDTO], summary="Search users by username prefix")
+@cache(expire=5)
 @pre_authorize([UserRole.user, UserRole.admin])
 def search_by_username_prefix(jwt: JWTDep, query: str, org_id_to_exclude_members: int = 0, user_service: UserService = Depends(get_user_service)):
     users = user_service.search_by_username_prefix(query, org_id_to_exclude_members)
     return users
 
 @router.get("/{username}", status_code=200, response_model=UserDTO, summary="Get user's profile info")
+@cache(expire=10)
 @pre_authorize([UserRole.user, UserRole.admin, UserRole.superadmin])
 def get_user_profile(jwt: JWTDep, username: str, user_service: UserService = Depends(get_user_service)):
     user = user_service.find_by_username(username)

--- a/server/app/tests/test_z_events.py
+++ b/server/app/tests/test_z_events.py
@@ -8,11 +8,27 @@ def test_events___integration():
     with TestClient(app) as client:
         assert wait_for_elasticsearch()
 
-        def search_for_something():
-            response = client.get(f"/api/v1/events/?query=date_time+%3C%3D+%222165-07-24%22&page_number=1&page_size=10&sort_by=date_time&sort_ascending=true")
+        def search_for_something(headers):
+            response = client.get(
+                f"/api/v1/events/?query=date_time+%3C%3D+%222165-07-24%22&page_number=1&page_size=10&sort_by=date_time&sort_ascending=true",
+                headers=headers)
             return response
-        
-        res = search_for_something()
+
+        def login(data: dict) -> dict:
+            response = client.post("/api/v1/users/login", json=data)
+            assert response.status_code == 200
+            jwt = response.json()["token"]
+            return {"Authorization": f"Bearer {jwt}"}
+
+        superadmin_creds = {
+            "username": "admin",
+            "password": "Password1" # WARNING: Superadmin password is changed by an earlier test (update user badge?)
+            # Therefore, that must run before this!
+        }
+
+        superadmin_header = login(superadmin_creds)
+
+        res = search_for_something(superadmin_header)
         assert res.is_success
 
         hits = res.json()["hits"]

--- a/server/app/tests/test_z_events.py
+++ b/server/app/tests/test_z_events.py
@@ -1,8 +1,139 @@
+import logging
 from fastapi.testclient import TestClient
 
-
+from datetime import datetime
 from app.api.main import app
 from app.api.config.elasticsearch import wait_for_elasticsearch
+
+from fastapi.testclient import TestClient
+from app.api.events.event_model import EventLevel
+import pytest
+from app.api.events.event_service import EventService
+from app.api.main import app
+from unittest.mock import MagicMock, patch
+from app.api.config.pagination import PaginatedResultDTO
+
+class TestEventService:
+
+    # -------------------------------
+    # Logging Tests
+    # -------------------------------
+
+    def test_log_read_logs_correct_message(self):
+        service = EventService()
+        with patch.object(service, 'log') as mock_log:
+            service.log_read(user_id=42, entity_type=str, entity_identifier="abc123")
+            mock_log.assert_called_once_with(EventLevel.Info, "User 42 wants to read str abc123")
+
+    def test_event_level_to_log_level_mapping(self):
+        service = EventService()
+        assert service._event_level_to_log_level(EventLevel.Debug) == logging.DEBUG
+        assert service._event_level_to_log_level(EventLevel.Info) == logging.INFO
+        assert service._event_level_to_log_level(EventLevel.Warning) == logging.WARNING
+        assert service._event_level_to_log_level(EventLevel.Error) == logging.ERROR
+
+        with pytest.raises(ValueError):
+            service._event_level_to_log_level("INVALID")
+
+    # -------------------------------
+    # Grammar Parsing & Query Conversion
+    # -------------------------------
+
+    @pytest.mark.parametrize("query_str,expected", [
+        ('status == "active"', {'term': {'status': 'active'}}),
+        ('status != "inactive"', {'bool': {'must_not': [{'term': {'status': 'inactive'}}]}}),
+        ('score >= "10"', {'range': {'score': {'gte': '10'}}}),
+        ('name ~= "john"', {'match': {'name': 'john'}}),
+        ('name ~~= "john doe"', {'match_phrase': {'name': 'john doe'}}),
+    ])
+    def test_to_query_basic_conditions(self, query_str, expected):
+        service = EventService()
+        model = service.meta.model_from_str(query_str)
+        query = service._to_query(model)
+        assert query.to_dict() == expected
+
+    def test_to_query_logical_and_or(self):
+        service = EventService()
+        model = service.meta.model_from_str('status == "active" and score > "10" or name ~= "john"')
+        query = service._to_query(model)
+        assert 'bool' in query.to_dict()
+
+    def test_to_query_not_expression(self):
+        service = EventService()
+        model = service.meta.model_from_str('not status == "inactive"')
+        query = service._to_query(model)
+        assert query.to_dict() == {
+            'bool': {
+                'must_not': [{'term': {'status': 'inactive'}}]
+            }
+        }
+
+    # -------------------------------
+    # Query Execution & Pagination
+    # -------------------------------
+
+    @patch('app.api.events.event_service.Search')
+    def test_query_executes_correctly(self, mock_search_cls):
+        mock_hit = MagicMock()
+        mock_hit.date_time = "2025-01-01T00:00:00"
+        mock_hit.log_level = "INFO"
+        mock_hit.text_content = "Test log"
+
+        mock_response = MagicMock()
+        mock_response.hits.total.value = 1
+        mock_response.__iter__.return_value = [mock_hit]
+
+        mock_search = MagicMock()
+        mock_search.query.return_value = mock_search
+        mock_search.sort.return_value = mock_search
+        mock_search.__getitem__.return_value = mock_search
+        mock_search.execute.return_value = mock_response
+
+        mock_search_cls.return_value = mock_search
+
+        service = EventService()
+        result = service.query(
+            query_string='log_level == "INFO"',
+            page_num=1,
+            page_size=10,
+            sort_by='date_time',
+            sort_asc=True
+        )
+
+        assert result.info.total_hits == 1
+        assert result.hits[0].text == "Test log"
+        assert result.hits[0].level == "INFO"
+        assert result.hits[0].date_time == datetime(2025, 1, 1, 0, 0)
+
+    @patch('app.api.events.event_service.Search')
+    def test_query_invalid_sort_field_skips_sorting(self, mock_search_cls):
+        mock_response = MagicMock()
+        mock_response.hits.total.value = 0
+        mock_response.__iter__.return_value = []
+
+        mock_search = MagicMock()
+        mock_search.query.return_value = mock_search
+        mock_search.__getitem__.return_value = mock_search
+        mock_search.execute.return_value = mock_response
+
+        mock_search_cls.return_value = mock_search
+
+        service = EventService()
+        result = service.query(
+            query_string='log_level == "INFO"',
+            page_num=1,
+            page_size=10,
+            sort_by='text_content', # Unsupported field
+            sort_asc=True
+        )
+
+        assert result.info.total_hits == 0
+        assert result.hits == []
+
+    def test_query_invalid_grammar_raises_exception(self):
+        service = EventService()
+        with pytest.raises(Exception):
+            service.meta.model_from_str('status === "active"') # Invalid operator
 
 def test_events___integration():
     with TestClient(app) as client:


### PR DESCRIPTION
Closes #71 

To be honest, I don't see any difference. The fastapi cache library doesn't support logging (I've tried) so you can't even see when a cache hit/miss happens. There's only the "100 changes in past 300 seconds" log from Redis itself as an indicator that _something_ is happening. Besides, all of our methods are blazing-fast. I'd need to spin up a Locust performance test to really see if there are any differences.
Either way, we already use Redis for job queues, so it's fine. It's not like this was a major thing that needed implementation - it was just a recommendation in the project spec.