### PR TITLE
Feature change org image

### DIFF
--- a/client/src/api/org.api.ts
+++ b/client/src/api/org.api.ts
@@ -41,6 +41,10 @@ export interface OrgDescUpdateDTO {
     desc: string
 }
 
+export interface OrgImageUpdateDTO {
+    image: string
+}
+
 export class OrganizationService {
 
     static async CreateOrganization(dto: OrganizationCreateDTO): Promise<AxiosResponse<OrganizationDTOBasic>> {
@@ -58,16 +62,16 @@ export class OrganizationService {
     static GetImageURI = (filename: string): string => {
         return `${ENV.IMG}${filename}`;
     }
-        
+
     static async AmIMemberOfOrg(org_id: number): Promise<AxiosResponse<OrganizationHasMemberDTO>> {
         return await axiosInstance.get(`/organizations/me/${org_id}`);
     }
 
-    static async DeleteOrg(orgName: string) : Promise<AxiosResponse<DeleteOrgResponseDTO>> {
+    static async DeleteOrg(orgName: string): Promise<AxiosResponse<DeleteOrgResponseDTO>> {
         return await axiosInstance.delete(`/registry/organization/${orgName}`)
     }
 
-    static async UpdateOrgDescByName(orgName: string, dto: OrgDescUpdateDTO) : Promise<AxiosResponse<OrganizationDTOBasic>> {
+    static async UpdateOrgDescByName(orgName: string, dto: OrgDescUpdateDTO): Promise<AxiosResponse<OrganizationDTOBasic>> {
         return await axiosInstance.put(`/organizations/${orgName}/desc`, dto)
     }
 
@@ -77,6 +81,14 @@ export class OrganizationService {
 
     static async AddUsersToOrg(org_id: number, user_ids: number[]) {
         return await axiosInstance.post(`/organizations/${org_id}/addMember`, user_ids);
+    }
+
+    static async UpdateOrgImageByName(orgName: string, dto: OrgImageUpdateDTO): Promise<AxiosResponse<OrganizationDTOBasic>> {
+        return await axiosInstance.put(`/organizations/${orgName}/image`, dto)
+    }
+
+    static async ClearOrgImageByName(orgName: string): Promise<AxiosResponse<OrganizationDTOBasic>> {
+        return await axiosInstance.put(`/organizations/${orgName}/image/clear`)
     }
 }
 

--- a/client/src/components/OrgOverview.tsx
+++ b/client/src/components/OrgOverview.tsx
@@ -63,8 +63,10 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
         }
 
         const base64 = await fileToBase64(file);
+        console.log(base64);
         OrganizationService.UpdateOrgImageByName(props.org.name, { image: base64 })
             .then((res) => {
+                console.log(res.data.image);
                 props.setOrg({ ...props.org, ...res.data });
                 setImagePreview(OrganizationService.GetImageURI(res.data.image));
                 addToast(`Updated image for ${props.org.name}. Your changes will be visible shortly.`, ToastType.success);

--- a/client/src/components/OrgOverview.tsx
+++ b/client/src/components/OrgOverview.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { OrganizationDTOBasic, OrganizationService, OrgDescUpdateDTO } from '../api/org.api';
 import { ToastType, useToastStore } from '../util/toastStore';
-import { Alert } from 'react-bootstrap';
+import { Alert, FloatingLabel } from 'react-bootstrap';
 import { AxiosError } from 'axios';
 import { getJwtId } from '../util/localstorage';
 import { fileToBase64 } from '../util/image';
@@ -93,10 +93,10 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
     };
 
     return (
-        <>
+        <div style={{ width: '80%', margin: 'auto' }}>
             {error && <Alert variant="danger">{error}</Alert>}
 
-            <div className="mb-3 ktext-center">
+            <div className="mb-3 text-center">
                 <img
                     src={imagePreview || '/default-org.png'}
                     alt="Organization"
@@ -119,6 +119,8 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
                 />
             </div>
 
+            <hr />
+
             <div className="tab-pane fade show active" id="overview">
                 {isEditing ? (
                     <div>
@@ -140,7 +142,11 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
                     </div>
                 ) : (
                     <div className="d-flex align-items-center">
-                        <div className='repo-page-desc'>{props.org.desc}</div>
+                        {props.org.desc !== "" ? (
+                            <div className='repo-page-desc'>{props.org.desc}</div>
+                        ) : (
+                            <i className='repo-page-desc'>No description provided</i>
+                        )}
                         {amOwnerOfOrg && (
                             <button className="btn btn-link p-0 ms-2" onClick={() => setIsEditing(true)}>
                                 <i className="bi bi-pencil"></i>
@@ -149,6 +155,6 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
                     </div>
                 )}
             </div>
-        </>
+        </div>
     );
 };

--- a/client/src/components/OrgOverview.tsx
+++ b/client/src/components/OrgOverview.tsx
@@ -1,25 +1,26 @@
-import React, { useEffect, useState } from 'react';
-import { RepoExtDTO, RepositoryService } from '../api/repo.api';
-import { RepositoryDescUpdateDTO } from '../api/repo.api';
-import { ToastType, useToastStore } from '../util/toastStore';
-import { Alert, Card } from 'react-bootstrap';
-import { AxiosError } from 'axios';
+import React, { useEffect, useRef, useState } from 'react';
 import { OrganizationDTOBasic, OrganizationService, OrgDescUpdateDTO } from '../api/org.api';
+import { ToastType, useToastStore } from '../util/toastStore';
+import { Alert } from 'react-bootstrap';
+import { AxiosError } from 'axios';
 import { getJwtId } from '../util/localstorage';
+import { fileToBase64 } from '../util/image';
 
 export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasic, setOrg: any }> = (props) => {
     const [isEditing, setIsEditing] = useState(false);
     const [newDesc, setNewDesc] = useState(props.org.desc);
-    const addToast = useToastStore((state) => state.addToast);
     const [error, setError] = useState('');
     const [amOwnerOfOrg, setAmOwnerOfOrg] = useState(false);
-    
+    const [imagePreview, setImagePreview] = useState<string | null>(OrganizationService.GetImageURI(props.org.image));
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const addToast = useToastStore((state) => state.addToast);
+
     const checkIfIamOwnerOfOrg = () => {
         if (getJwtId() === props.org.owner_id) {
             setAmOwnerOfOrg(true);
         }
-    }
-    
+    };
+
     useEffect(() => {
         if (props.isActive) {
             checkIfIamOwnerOfOrg();
@@ -28,39 +29,112 @@ export const OrgOverview: React.FC<{ isActive: boolean; org: OrganizationDTOBasi
 
     const updateDescription = () => {
         setIsEditing(false);
+        const dto: OrgDescUpdateDTO = { desc: newDesc };
 
-        let dto: OrgDescUpdateDTO = {
-            desc: newDesc,
-        };
-        
-        OrganizationService.UpdateOrgDescByName(props.org.name, dto).then((res) => {
-            props.setOrg({
-                ...props.org,
-                ...res.data,
+        OrganizationService.UpdateOrgDescByName(props.org.name, dto)
+            .then((res) => {
+                props.setOrg({ ...props.org, ...res.data });
+                addToast(`Updated the description of ${props.org.name}.`, ToastType.success);
+                setError('');
+            })
+            .catch((err: AxiosError) => {
+                setError((err.response?.data as any)?.detail?.message || 'Failed to update description.');
             });
-            addToast(`Updated the description of ${props.org.name}.`, ToastType.success);
-            setError('');
-        }).catch((err: AxiosError) => {
-            setError((err.response?.data as any)["detail"]["message"]);
-        });
+    };
+
+    const handleImageClick = () => {
+        if (amOwnerOfOrg && fileInputRef.current) {
+            fileInputRef.current.click();
+        }
+    };
+
+    const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+
+        if (!['image/png', 'image/jpeg'].includes(file.type)) {
+            setError('Only PNG and JPEG files are allowed.');
+            return;
+        }
+
+        if (file.size > 2 * 1024 * 1024) { // 2MB limit
+            setError('Image size must be less than 2MB.');
+            return;
+        }
+
+        const base64 = await fileToBase64(file);
+        OrganizationService.UpdateOrgImageByName(props.org.name, { image: base64 })
+            .then((res) => {
+                props.setOrg({ ...props.org, ...res.data });
+                setImagePreview(OrganizationService.GetImageURI(res.data.image));
+                addToast(`Updated image for ${props.org.name}. Your changes will be visible shortly.`, ToastType.success);
+                setError('');
+            })
+            .catch((err: AxiosError) => {
+                setError((err.response?.data as any)?.detail?.message || 'Failed to update image.');
+            });
+    };
+
+    const clearImage = () => {
+        OrganizationService.ClearOrgImageByName(props.org.name)
+            .then((res) => {
+                props.setOrg({ ...props.org, ...res.data });
+                //setImagePreview(null);
+                addToast(`Cleared image for ${props.org.name}. Your changes will be visible shortly.`, ToastType.success);
+                setError('');
+            })
+            .catch((err: AxiosError) => {
+                setError((err.response?.data as any)?.detail?.message || 'Failed to clear image.');
+            });
+
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
     };
 
     return (
         <>
-            {/* Consider placing the image next to the organization name */}
-            <img src={OrganizationService.GetImageURI(props.org.image)} className="mb-3"/> 
+            {error && <Alert variant="danger">{error}</Alert>}
+
+            <div className="mb-3 ktext-center">
+                <img
+                    src={imagePreview || '/default-org.png'}
+                    alt="Organization"
+                    style={{ maxWidth: '200px', maxHeight: '200px', cursor: amOwnerOfOrg ? 'pointer' : 'default' }}
+                    onClick={handleImageClick}
+                />
+                {amOwnerOfOrg && imagePreview && (
+                    <div className="mt-2">
+                        <button className="btn btn-sm btn-outline-danger" onClick={clearImage}>
+                            Clear Image
+                        </button>
+                    </div>
+                )}
+                <input
+                    type="file"
+                    accept="image/png, image/jpeg"
+                    style={{ display: 'none' }}
+                    ref={fileInputRef}
+                    onChange={handleImageChange}
+                />
+            </div>
 
             <div className="tab-pane fade show active" id="overview">
-                {error && <Alert variant="danger">{error}</Alert>}
                 {isEditing ? (
                     <div>
-                        <textarea className="form-control" rows={7} value={newDesc} onChange={(e) => setNewDesc(e.target.value)} autoFocus/>
+                        <textarea
+                            className="form-control"
+                            rows={7}
+                            value={newDesc}
+                            onChange={(e) => setNewDesc(e.target.value)}
+                            autoFocus
+                        />
                         <div className='mt-3'>
-                            <button className="btn btn-primary me-2" onClick={updateDescription}> 
+                            <button className="btn btn-primary me-2" onClick={updateDescription}>
                                 Update description
                             </button>
-                            <button className="btn btn-secondary" onClick={() => { setIsEditing(false); setNewDesc(props.org.desc); }}> 
-                                Cancel 
+                            <button className="btn btn-secondary" onClick={() => { setIsEditing(false); setNewDesc(props.org.desc); }}>
+                                Cancel
                             </button>
                         </div>
                     </div>

--- a/server/app/api/events/event_service.py
+++ b/server/app/api/events/event_service.py
@@ -13,6 +13,12 @@ from textx import metamodel_from_str
 
 class EventService:
     def __init__(self):
+        self.meta = None
+
+    def build_metamodel(self):
+        if self.meta is not None:
+            return
+        
         query_grammar = r'''
             Model: expr ;
 
@@ -152,6 +158,8 @@ class EventService:
         """
         High-level method for submitting a query.
         """
+
+        self.build_metamodel()
 
         model = self.meta.model_from_str(query_string)
         query = self._to_query(model)

--- a/server/app/api/org/org_controller.py
+++ b/server/app/api/org/org_controller.py
@@ -5,7 +5,7 @@ from app.api.config.auth import get_id_from_jwt, get_id_from_jwt_optional, pre_a
 from app.api.user.user_dto import UserDTO
 from app.api.user.user_model import UserRole
 from app.api.config.auth import JWTDep, JWTDepOptional
-from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDTO, OrganizationDTOBasic, OrganizationDescUpdateDTO, OrganizationHasMemberDTO
+from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDTO, OrganizationDTOBasic, OrganizationDescUpdateDTO, OrganizationHasMemberDTO, OrganizationImageUpdateDTO
 from app.api.org.org_service import OrganizationService, get_org_service
 from app.api.access_control.access_control_service import AccessControlService
 
@@ -63,3 +63,24 @@ def add_members_to_org(jwt: JWTDep, org_id: int, user_ids: List[int], org_servic
     owner_id = get_id_from_jwt(jwt)
     result = org_service.add_members_to_org(org_id, user_ids, owner_id)
     return result
+
+@router.put("/{org_name}/image", response_model=OrganizationDTO, status_code=200, summary="Update organization description by its name")
+@pre_authorize([UserRole.user, UserRole.admin])
+def update_org_image_by_name(
+    jwt: JWTDep, org_name: str, 
+    dto: OrganizationImageUpdateDTO, 
+    org_service: OrganizationService = Depends(get_org_service)):
+    user_id = get_id_from_jwt(jwt)
+    org = org_service.update_image_by_name(org_name, dto, user_id)
+    return org
+
+@router.put("/{org_name}/image/clear", response_model=OrganizationDTO, status_code=200, summary="Update organization description by its name")
+@pre_authorize([UserRole.user, UserRole.admin])
+def clear_org_image_by_name(
+    jwt: JWTDep, org_name: str, 
+    org_service: OrganizationService = Depends(get_org_service)):
+
+    dto = OrganizationImageUpdateDTO(image="")
+    user_id = get_id_from_jwt(jwt)
+    org = org_service.update_image_by_name(org_name, dto, user_id)
+    return org

--- a/server/app/api/org/org_dto.py
+++ b/server/app/api/org/org_dto.py
@@ -34,3 +34,6 @@ class OrganizationHasMemberDTO(BaseModel):
 
 class OrganizationDescUpdateDTO(BaseModel):
     desc: str
+
+class OrganizationImageUpdateDTO(BaseModel):
+    image: str

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 from fastapi import Depends
 from sqlmodel import Session
 from app.api.config.database import get_database
-from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDescUpdateDTO
+from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDescUpdateDTO, OrganizationImageUpdateDTO
 from app.api.org.org_model import Organization, OrganizationMembers
 from app.api.org.org_repo import OrganizationRepo
 from app.api.config.exception_handler import AccessDeniedException, FieldTakenException, NotFoundException
@@ -10,6 +10,8 @@ from app.api.config.images import generate_inline_image, save_image
 from app.api.repo.repo_model import Repository
 from app.api.user.user_model import User
 from app.api.user.user_repo import UserRepo
+from app.api.events.event_service import EventService
+from app.api.events.event_model import EventLevel
 
 
 class OrganizationService:
@@ -17,6 +19,7 @@ class OrganizationService:
         self.session = session
         self.org_repo = OrganizationRepo(session)
         self.user_repo = UserRepo(session)
+        self.event_service = EventService()
 
     def add(self, user_id: int, dto: OrganizationCreateDTO) -> Organization:
         # Check if the name is available.
@@ -101,6 +104,22 @@ class OrganizationService:
         if user_id != org.owner.id:
             raise AccessDeniedException(f"User {user_id} cannot update organization description with identifier {name}")
         self.update_org_attrs(name, desc=dto.desc)
+        return org
+    
+    def update_image_by_name(self, name: str, dto: OrganizationImageUpdateDTO, user_id: int) -> Organization:
+        org = self.find_by_name(name)
+        if user_id != org.owner.id:
+            raise AccessDeniedException(f"User {user_id} cannot update organization image with identifier {name}")
+
+
+        if dto.image is None or dto.image == "":
+            self.event_service.log(EventLevel.Info, f"User {user_id} is clearing image from org {name}")
+            dto.image = generate_inline_image(name)
+        else:
+            self.event_service.log(EventLevel.Info, f"User {user_id} is setting image for org {name}")
+            
+        save_image(dto.image, f"org-{name}")[1]
+
         return org
 
     def update_org_attrs(self, name: str, **kwargs) -> Organization:

--- a/server/app/api/org/org_service.py
+++ b/server/app/api/org/org_service.py
@@ -13,6 +13,7 @@ from app.api.user.user_model import User
 from app.api.user.user_repo import UserRepo
 from app.api.events.event_service import EventService
 from app.api.events.event_model import EventLevel
+from app.api.config.logutil import LOGGER
 
 
 class OrganizationService:
@@ -109,10 +110,11 @@ class OrganizationService:
         return org
     
     def update_image_by_name(self, name: str, dto: OrganizationImageUpdateDTO, user_id: int) -> Organization:
+        self.event_service.log(EventLevel.Info, f"User {user_id} wants to change image of organization {name}")
+
         org = self.find_by_name(name)
         if user_id != org.owner.id:
             raise AccessDeniedException(f"User {user_id} cannot update organization image with identifier {name}")
-
 
         if dto.image is None or dto.image == "":
             self.event_service.log(EventLevel.Info, f"User {user_id} is clearing image from org {name}")
@@ -120,7 +122,11 @@ class OrganizationService:
         else:
             self.event_service.log(EventLevel.Info, f"User {user_id} is setting image for org {name}")
             
-        save_image(dto.image, f"org-{name}")[1]
+        fname = save_image(dto.image, f"org-{name}")[1]
+        
+        self.event_service.log(EventLevel.Info, f"Org {name} image changed! New filename: {fname}")
+
+        org = self.update_org_attrs(name, image=fname)
 
         return org
 

--- a/server/app/tests/test_organization.py
+++ b/server/app/tests/test_organization.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, call
 from fastapi.testclient import TestClient
 import pytest
 from app.api.org.org_service import OrganizationService
-from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDescUpdateDTO
+from app.api.org.org_dto import OrganizationCreateDTO, OrganizationDescUpdateDTO, OrganizationImageUpdateDTO
 from app.api.config.exception_handler import AccessDeniedException, FieldTakenException, NotFoundException
 from app.api.config.exception_handler import FieldTakenException
 from app.api.main import app
@@ -626,4 +626,162 @@ class TestAddMembersToOrg:
             assert "jane" not in member_usernames
 
 
+
+class TestUpdateOrgImgByName:
+    IMG = "data:image/png;base64,R0lGODlhAQABAAAAACw=" # Note: this isn't actually a valid PNG, but it's a valid encoding.
+
+    def test_org_not_exist(self, org_service):
+        """ Test case for when organization does not exist. """
+        user_id = 1
+        dto = OrganizationImageUpdateDTO(image=TestUpdateOrgImgByName.IMG)
+        org_name = "o1"
+        org_service.org_repo.find_by_name.return_value = None
+
+        with pytest.raises(NotFoundException):
+            org_service.update_image_by_name(org_name, dto, user_id)
+
+        org_service.org_repo.set_attribute.assert_not_called()
+        org_service.org_repo.find_by_name.assert_called_once_with(org_name)
+
+    def test_non_eligible_user(self, org_service):
+        """ Test case for when the user is not eligible to make an update. """
+        user_id = 1
+        dto = OrganizationImageUpdateDTO(image=TestUpdateOrgImgByName.IMG)
+
+        owner = MagicMock(spec=User)
+        owner.id = 999999
+        org = MagicMock(spec=Organization)
+        org.name = "o1"
+        org.owner = owner
+
+        org_service.org_repo.find_by_name.return_value = org
+
+        with pytest.raises(AccessDeniedException):
+            org_service.update_image_by_name(org.name, dto, user_id)
+
+        org_service.org_repo.set_attribute.assert_not_called()
+        org_service.org_repo.find_by_name.assert_called_once_with(org.name)
+
+    def test_successful_update(self, org_service):
+        """ Test case for when the user is eligible and organization does exist. """
+        dto = OrganizationImageUpdateDTO(image=TestUpdateOrgImgByName.IMG)
+        user = MagicMock(spec=User)
+        user.id = 1
+        org = MagicMock(spec=Organization)
+        org.name = "o1"
+        org.owner = user
+
+        org_service.org_repo.find_by_name.return_value = org
+
+        result = org_service.update_image_by_name(org.name, dto, user.id)
+        assert result.name == org.name
+
+    @pytest.mark.parametrize("user_type", [("user"), ("admin")])
+    def integration_test(self, user_type):
+        with TestClient(app) as client:
+            def add_user(username):
+                data = {
+                    "username": username,
+                    "email": f"{username}@gmail.com",
+                    "password": "12345678"
+                }
+                response = client.post("/api/v1/users/", json=data)
+                return response.json()
+
+            def log_in(username: str, password: str = "12345678"):
+                data = {
+                    "username": username,
+                    "password": password
+                }
+                response = client.post("/api/v1/users/login", json=data)
+                if response.status_code == 400:
+                    assert response.json() == False
+                jwt = response.json()["token"]
+                return jwt
+
+            def change_superadmin_password():
+                # [1] Loading the super admin credentials
+                config_file = "./volume-server-cfg/superadmin_password.txt"
+
+                with open(config_file, "r") as f:
+                    old_password = f.readline()
+
+                jwt = log_in("admin", old_password)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+                # [2] Changing the super admin password
+                data = {
+                    "old_password": old_password,
+                    "new_password": "12345678"
+                }
+                response = client.post("/api/v1/users/password", json=data, headers=header)
+                assert response.is_success
+
+            def add_admin(admin_username: str) -> dict:
+                jwt = log_in("admin", "12345678")
+                header = {"Authorization": f"Bearer {jwt}"}
+                data = {
+                    "username": admin_username,
+                    "email": f"{admin_username}@gmail.com",
+                    "password": "12345678"
+                }
+                response = client.post("/api/v1/users/register-admin", json=data, headers=header)
+                created_admin = response.json()
+
+                return created_admin
+
+            def add_org(username, name: str) -> dict:
+                jwt = log_in(username)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+                dto1 = {
+                    "name": name,
+                    "desc": "",
+                    "owner"
+                    "image": None
+                }
+                return client.post("/api/v1/organizations", json=dto1, headers=header).json()
+
+            def update_img(username: str, org_name: str, image: str):
+                jwt = log_in(username)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+                data = {
+                    "image": image
+                }
+
+                response = client.put(f"/api/v1/organizations/{org_name}/image", json=data, headers=header)
+                return response
+            
+            def clear_img(username: str, org_name: str):
+                jwt = log_in(username)
+                header = {"Authorization": f"Bearer {jwt}"}
+
+
+                response = client.put(f"/api/v1/organizations/{org_name}/image/clear", headers=header)
+                return response
+
+            if (user_type == "user"):
+                add_user("u1")
+                add_user("u2")
+            else:
+                change_superadmin_password()
+                add_admin("u1")
+                add_admin("u2")
+
+            o1 = add_org("u1", "o1")
+
+            # User who is the organization owner
+            assert update_img("u1", o1["name"], TestUpdateOrgImgByName.IMG).is_success
+            # User who is trying to update a non existing organization
+            assert update_img("u1", "unknown org", TestUpdateOrgImgByName.IMG).status_code == 400
+            # User who is not an organization owner
+            assert update_img("u2", o1["id"], TestUpdateOrgImgByName.IMG).status_code == 400
+
+            # User who is the organization owner
+            assert clear_img("u1", o1["name"]).is_success
+            # User who is trying to update a non existing organization
+            assert clear_img("u1", "unknown org").status_code == 400
+            # User who is not an organization owner
+            assert clear_img("u2", o1["id"]).status_code == 400
 

--- a/server/app/tests/test_organization.py
+++ b/server/app/tests/test_organization.py
@@ -704,6 +704,7 @@ class TestUpdateOrgImgByName:
         org.owner = user
 
         org_service.org_repo.find_by_name.return_value = org
+        org_service.org_repo.set_attribute.return_value = org
 
         result = org_service.update_image_by_name(org.name, dto, user.id)
         assert result.name == org.name


### PR DESCRIPTION
Closes #73 

Pretty self explanatory. Clicking on an image opens the file picker. Please make sure to test it manually:
- change image
- remove image
- also, check if searching for logs still works, because I changed something in the EventService

When you remove the image, it regenerates the default image. Since that image gen function is not random, it'll always create the same image for a single organization.

The changes won't be seen immediately. You may need to Ctrl+F5. I had to run it in incognito. It literally wouldn't change because of browser cache. 